### PR TITLE
PLT#28 removing useless migrations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,12 @@ addons:
 before_script:
   - psql -c 'create database travis_ci_test;' -U postgres
   - cp config/database.yml.travis config/database.yml
+webhooks:
+    urls:
+        - https://webhooks.gitter.im/e/c5e0daae1aef95763ea2
+    on_success: always  # options: [always|never|change] default: always
+    on_failure: always  # options: [always|never|change] default: always
+    on_start: false     # default: false
+
 # uncomment this line if your project needs to run something other than `rake`:
 # script: bundle exec rspec spec

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'jquery-rails'
 
 # Use debugger
 # gem 'debugger', group: [:development, :test]
-gem 'cancan'
+gem 'cancancan'
 
 gem 'responders'
 gem 'devise', '~> 3.5.0'                # Flexible authentication solution for Rails with Warden
@@ -47,8 +47,6 @@ gem 'devise-token_authenticatable', "~> 0.4.0" # Token Authenticatable module of
 gem 'default_value_for', '3.0.1'      # Provides a way to specify default values for ActiveRecord models
 gem 'will_paginate', '~> 3.0.6'       # Pagination library for Rails
 gem 'active_model_serializers', '0.8.3' # ActiveModel::Serializer implementation and Rails hooks
-
-gem 'cancan'
 
 gem 'simple-navigation'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,3 +240,6 @@ DEPENDENCIES
   web-console (~> 2.0)
   webrat (= 0.7.3)
   will_paginate (~> 3.0.6)
+
+BUNDLED WITH
+   1.10.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ GEM
     builder (3.2.2)
     byebug (5.0.0)
       columnize (= 0.9.0)
-    cancan (1.6.10)
+    cancancan (1.10.1)
     carrierwave (0.10.0)
       activemodel (>= 3.2.0)
       activesupport (>= 3.2.0)
@@ -212,7 +212,7 @@ DEPENDENCIES
   active_model_serializers (= 0.8.3)
   annotate
   byebug
-  cancan
+  cancancan
   carrierwave
   coffee-rails (~> 4.1.0)
   default_value_for (= 3.0.1)

--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -1,0 +1,90 @@
+# PostgreSQL. Versions 8.2 and up are supported.
+#
+# Install the pg driver:
+#   gem install pg
+# On OS X with Homebrew:
+#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
+# On OS X with MacPorts:
+#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
+# On Windows:
+#   gem install pg
+#       Choose the win32 build.
+#       Install PostgreSQL and put its /bin directory on your path.
+#
+# Configure Using Gemfile
+# gem 'pg'
+#
+default: &default
+  adapter: postgresql
+  encoding: utf-8
+  # For details on connection pooling, see rails configuration guide
+  # http://guides.rubyonrails.org/configuring.html#database-pooling
+  host: www.yourdomain.me
+  username: fill_in_your_username
+  password: fill_in_your_password
+  pool: 5
+
+development:
+  <<: *default
+  database: PLT_development
+
+  # The specified database role being used to connect to postgres.
+  # To create additional roles in postgres see `$ createuser --help`.
+  # When left blank, postgres will use the default role. This is
+  # the same name as the operating system user that initialized the database.
+  #username: PLT
+
+  # The password associated with the postgres role (username).
+  #password:
+
+  # Connect on a TCP socket. Omitted by default since the client uses a
+  # domain socket that doesn't need configuration. Windows does not have
+  # domain sockets, so uncomment these lines.
+  #host: localhost
+
+  # The TCP port the server listens on. Defaults to 5432.
+  # If your server runs on a different port number, change accordingly.
+  #port: 5432
+
+  # Schema search path. The server defaults to $user,public
+  #schema_search_path: myapp,sharedapp,public
+
+  # Minimum log levels, in increasing order:
+  #   debug5, debug4, debug3, debug2, debug1,
+  #   log, notice, warning, error, fatal, and panic
+  # Defaults to warning.
+  #min_messages: notice
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+test:
+  <<: *default
+  database: PLT_test
+
+# As with config/secrets.yml, you never want to store sensitive information,
+# like your database password, in your source code. If your source code is
+# ever seen by anyone, they now have access to your database.
+#
+# Instead, provide the password as a unix environment variable when you boot
+# the app. Read http://guides.rubyonrails.org/configuring.html#configuring-a-database
+# for a full rundown on how to provide these environment variables in a
+# production deployment.
+#
+# On Heroku and other platform providers, you may have a full connection URL
+# available as an environment variable. For example:
+#
+#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
+#
+# You can use this database configuration with:
+#
+#   production:
+#     url: <%= ENV['DATABASE_URL'] %>
+#
+production:
+  <<: *default
+  database: PLT_production
+
+staging:
+  <<: *default
+  database: PLT_development

--- a/db/migrate/20140625230123_remove_email_from_users.rb
+++ b/db/migrate/20140625230123_remove_email_from_users.rb
@@ -1,5 +1,0 @@
-class RemoveEmailFromUsers < ActiveRecord::Migration
-  def change
-    remove_column :users, :email, :string
-  end
-end

--- a/db/migrate/20140625230914_add_email_to_users.rb
+++ b/db/migrate/20140625230914_add_email_to_users.rb
@@ -1,5 +1,0 @@
-class AddEmailToUsers < ActiveRecord::Migration
-  def change
-    add_column :users, :email, :string
-  end
-end

--- a/db/migrate/20140626003527_remove_username_from_users.rb
+++ b/db/migrate/20140626003527_remove_username_from_users.rb
@@ -1,5 +1,0 @@
-class RemoveUsernameFromUsers < ActiveRecord::Migration
-  def change
-    remove_column :users, :username, :string
-  end
-end


### PR DESCRIPTION
Issue #28  - Removing Useless Migrations, #29 - CanCan --> CanCanCan

1.Get rid of migrations that do nothing / generates errors.
2.Replace the deprecated CanCan gem with its continuation, CanCanCan

Other minor changes:
1.Update Bundler version to 1.10.3 and update Gemfile.lock with an extra line generated by the bundler
2.Add `config/database.yml.example` to help novice users get a quick glimpse of the file.
3.Add Slack integration with Travis CI to push build results to our Slack channel

Author : @wonook - Won Wook SONG (wsong0512@gmail.com)

This pull request closes #28 
This pull request closes #29 