### PR TITLE
Plt#45 fix login approval

### DIFF
--- a/app/assets/javascripts/components/users/index.js.jsx.coffee
+++ b/app/assets/javascripts/components/users/index.js.jsx.coffee
@@ -1,0 +1,47 @@
+@UsersIndexBox = React.createClass
+  getInitialState: ->
+    data: @props.data
+  render: ->
+    `<div className="UsersIndexBox">
+      <h3>Members</h3>
+      <UsersIndexList data={this.state.data}/>
+    </div>`
+
+@UsersIndexList = React.createClass
+  render: ->
+    userNodes = @props.data.map((user) ->
+      `<UserNode user={user} />`
+    )
+    `<table className="UserIndexList table table-striped">
+      <tr>
+        <th>Name</th>
+        <th>Gender</th>
+        <th>Email</th>
+        <th>Username</th>
+        <th>Location</th>
+        <th>Language</th>
+        <th>Mobile</th>
+        <th>Login Approval</th>
+      </tr>
+      {userNodes}
+    </table>`
+
+@UserNode = React.createClass
+  render: ->
+    login_approval =
+      if @props.user.login_approval_at
+      then  `<div>{this.props.user.login_approval_at.slice(0,10)}<button className='btn btn-default'><span className='glyphicon glyphicon-remove' /></button></div>`
+      else `<div>Waiting<button className='btn btn-default'><span className='glyphicon glyphicon-ok' /></button></div>`
+    show_url = "members/" + @props.user.id
+    `<div className="UserNode">
+      <tr>
+        <td><a href={show_url}>{this.props.user.first_name} {this.props.user.last_name}</a></td>
+        <td>{this.props.user.gender}</td>
+        <td>{this.props.user.email}</td>
+        <td>{this.props.user.username}</td>
+        <td>{this.props.user.location}</td>
+        <td>{this.props.user.lang}</td>
+        <td>{this.props.user.contact}</td>
+        <td>{login_approval}</td>
+      </tr>
+    </div>`

--- a/app/assets/javascripts/components/users/index.js.jsx.coffee
+++ b/app/assets/javascripts/components/users/index.js.jsx.coffee
@@ -1,47 +1,80 @@
 @UsersIndexBox = React.createClass
   getInitialState: ->
     data: @props.data
+  handleUserApproval: (userdata) ->
+    approveurl = 'members/approve.json'
+    disapproveurl = 'members/disapprove.json'
+    if userdata.action == 'approve'
+      $.ajax({
+        url: approveurl
+        dataType: 'json'
+        type: 'POST'
+        data: {user_id: userdata.user_id}
+        success: ((data) ->
+          @setState({data: data.users})).bind(this)
+        error: ((xhr, status, err) ->
+          console.error(approveurl, status, err.toString())).bind(this)
+      })
+    else if userdata.action == 'disapprove'
+      $.ajax({
+        url: disapproveurl
+        dataType: 'json'
+        type: 'POST'
+        data: {user_id: userdata.user_id}
+        success: ((data) ->
+          @setState({data: data.users})).bind(this)
+        error: ((xhr, status, err) ->
+          console.error(disapproveurl, status, err.toString())).bind(this)
+      })
   render: ->
     `<div className="UsersIndexBox">
       <h3>Members</h3>
-      <UsersIndexList data={this.state.data}/>
+      <UsersIndexList data={this.state.data} onUserApproval={this.handleUserApproval}/>
     </div>`
 
 @UsersIndexList = React.createClass
+  handleApproval: (data) ->
+    @props.onUserApproval(data)
   render: ->
+    clickApproval = @handleApproval
     userNodes = @props.data.map((user) ->
-      `<UserNode user={user} />`
-    )
+      `<UserNode key={user.id} user={user} onUserApproval={clickApproval}/>`)
     `<table className="UserIndexList table table-striped">
-      <tr>
-        <th>Name</th>
-        <th>Gender</th>
-        <th>Email</th>
-        <th>Username</th>
-        <th>Location</th>
-        <th>Language</th>
-        <th>Mobile</th>
-        <th>Login Approval</th>
-      </tr>
-      {userNodes}
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Gender</th>
+          <th>Email</th>
+          <th>Username</th>
+          <th>Location</th>
+          <th>Language</th>
+          <th>Mobile</th>
+          <th>Login Approval</th>
+        </tr>
+      </thead>
+      <tbody>{userNodes}</tbody>
     </table>`
 
 @UserNode = React.createClass
+  handleApproval: ->
+    user = @props.user
+    if user.login_approval_at
+      @props.onUserApproval({user_id: user.id, action: 'disapprove'})
+    else
+      @props.onUserApproval({user_id: user.id, action: 'approve'})
   render: ->
     login_approval =
       if @props.user.login_approval_at
-      then  `<div>{this.props.user.login_approval_at.slice(0,10)}<button className='btn btn-default'><span className='glyphicon glyphicon-remove' /></button></div>`
-      else `<div>Waiting<button className='btn btn-default'><span className='glyphicon glyphicon-ok' /></button></div>`
+      then  `<div>{this.props.user.login_approval_at.slice(0,10)}<button onClick={this.handleApproval} className='btn btn-default'><span className='glyphicon glyphicon-remove' /></button></div>`
+      else `<div>Waiting<button onClick={this.handleApproval} className='btn btn-default'><span className='glyphicon glyphicon-ok' /></button></div>`
     show_url = "members/" + @props.user.id
-    `<div className="UserNode">
-      <tr>
-        <td><a href={show_url}>{this.props.user.first_name} {this.props.user.last_name}</a></td>
-        <td>{this.props.user.gender}</td>
-        <td>{this.props.user.email}</td>
-        <td>{this.props.user.username}</td>
-        <td>{this.props.user.location}</td>
-        <td>{this.props.user.lang}</td>
-        <td>{this.props.user.contact}</td>
-        <td>{login_approval}</td>
-      </tr>
-    </div>`
+    `<tr>
+      <td><a href={show_url}>{this.props.user.first_name} {this.props.user.last_name}</a></td>
+      <td>{this.props.user.gender}</td>
+      <td>{this.props.user.email}</td>
+      <td>{this.props.user.username}</td>
+      <td>{this.props.user.location}</td>
+      <td>{this.props.user.lang}</td>
+      <td>{this.props.user.contact}</td>
+      <td>{login_approval}</td>
+    </tr>`

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,7 +36,7 @@ class ApplicationController < ActionController::Base
 
   def configure_devise_permitted_parameters
      registration_params = [:first_name, :last_name, :email,  :username, :password, :password_confirmation, :location,
-         :lang, :contact, :gender, :login_approval]
+         :lang, :contact, :gender]
 
      if params[:action] == 'update'
          devise_parameter_sanitizer.for(:account_update) { |u| u.permit(registration_params << :current_password)}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -47,7 +47,7 @@ class UsersController < ApplicationController
  
   private
   def user_params
-    params.require(:user).permit(:first_name, :last_name, :email, :username, :location, :lang, :contact, :gender, :login_approval)
+    params.require(:user).permit(:first_name, :last_name, :email, :username, :location, :lang, :contact, :gender)
   end
 
   def set_user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,9 +5,9 @@ class UsersController < ApplicationController
 
   def index
     if params[:q].blank?
-      @users = User.accessible_by(current_ability).paginate(page: params[:page], per_page: 20)
+      @users = User.accessible_by(current_ability)
     else
-      @users = User.accessible_by(current_ability).user_search(params[:q]).paginate(page: params[:page], per_page: 20)
+      @users = User.accessible_by(current_ability).user_search(params[:q])
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -44,6 +44,30 @@ class UsersController < ApplicationController
       render 'edit'
     end
   end
+
+  def approve_user
+    @user = User.find(params[:user_id])
+    @user.login_approval_at = Time.now
+    respond_to do |format|
+      if @user.save
+        format.json { render json: User.accessible_by(current_ability), status: :ok }
+      else
+        format.json { render json: @user.errors, status: :unprocessable_entity}
+      end
+    end
+  end
+
+  def disapprove_user
+    @user = User.find(params[:user_id])
+    @user.login_approval_at = nil
+    respond_to do |format|
+      if @user.save
+        format.json { render json: User.accessible_by(current_ability), status: :ok }
+      else
+        format.json { render json: @user.errors, status: :unprocessable_entity}
+      end
+    end
+  end
  
   private
   def user_params

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -7,8 +7,8 @@
 #  phonetic    :text
 #  created_at  :datetime
 #  updated_at  :datetime
-#  category    :string(255)
-#  picture     :string(255)
+#  category    :string
+#  picture     :string
 #  language_id :integer
 #  tsv_data    :tsvector
 #

--- a/app/models/installation.rb
+++ b/app/models/installation.rb
@@ -3,10 +3,10 @@
 # Table name: installations
 #
 #  id           :integer          not null, primary key
-#  installation :string(255)
-#  email        :string(255)
+#  installation :string
+#  email        :string
 #  address      :text
-#  contact      :string(255)
+#  contact      :string
 #  created_at   :datetime
 #  updated_at   :datetime
 #

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -3,7 +3,7 @@
 # Table name: languages
 #
 #  id         :integer          not null, primary key
-#  name       :string(255)
+#  name       :string
 #  created_at :datetime
 #  updated_at :datetime
 #

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: roles
+#
+#  id            :integer          not null, primary key
+#  name          :string
+#  resource_id   :integer
+#  resource_type :string
+#  created_at    :datetime
+#  updated_at    :datetime
+#
+
 class Role < ActiveRecord::Base
   has_and_belongs_to_many :users, :join_table => :users_roles
   belongs_to :resource, :polymorphic => true

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -3,7 +3,7 @@
 # Table name: sites
 #
 #  id              :integer          not null, primary key
-#  name            :string(255)
+#  name            :string
 #  installation_id :integer
 #  created_at      :datetime
 #  updated_at      :datetime

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,7 +47,7 @@ class User < ActiveRecord::Base
   default_scope -> { order('created_at DESC') }
   validates_uniqueness_of :username
   validates_confirmation_of :password, length: { in: 6..20 }
-  validates_presence_of :username, :login_approval, :first_name, :last_name
+  validates_presence_of :username, :email, :first_name, :last_name
 
   before_save :ensure_authentication_token
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,38 +3,28 @@
 # Table name: users
 #
 #  id                     :integer          not null, primary key
-#  encrypted_password     :string(255)      default("")
-#  reset_password_token   :string(255)
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  reset_password_token   :string
 #  reset_password_sent_at :datetime
 #  remember_created_at    :datetime
 #  sign_in_count          :integer          default(0), not null
 #  current_sign_in_at     :datetime
 #  last_sign_in_at        :datetime
-#  current_sign_in_ip     :string(255)
-#  last_sign_in_ip        :string(255)
+#  current_sign_in_ip     :string
+#  last_sign_in_ip        :string
 #  created_at             :datetime
 #  updated_at             :datetime
-#  first_name             :string(255)
-#  last_name              :string(255)
-#  email                  :string(255)
-#  username               :string(255)
-#  location               :string(255)
-#  contact                :string(255)
-#  gender                 :string(255)
-#  bk_role                :string(255)
-#  login_approval         :string(255)
-#  lang                   :string(255)
-#  role_id                :integer
+#  first_name             :string
+#  last_name              :string
+#  username               :string
+#  location               :string
+#  contact                :string
+#  gender                 :string
+#  lang                   :string
 #  tsv_data               :tsvector
-#  invitation_token       :string
-#  invitation_created_at  :datetime
-#  invitation_sent_at     :datetime
-#  invitation_accepted_at :datetime
-#  invitation_limit       :integer
-#  invited_by_id          :integer
-#  invited_by_type        :string
-#  invitations_count      :integer          default(0)
 #  authentication_token   :string
+#  login_approval_at      :datetime
 #
 
 class User < ActiveRecord::Base

--- a/app/serializers/article_serializer.rb
+++ b/app/serializers/article_serializer.rb
@@ -7,8 +7,8 @@
 #  phonetic    :text
 #  created_at  :datetime
 #  updated_at  :datetime
-#  category    :string(255)
-#  picture     :string(255)
+#  category    :string
+#  picture     :string
 #  language_id :integer
 #  tsv_data    :tsvector
 #

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -1,75 +1,73 @@
-<%# if current_user.login_approval == 'Yes' %>
+<%# if current_user.login_approval_at %>
 <%# if current_user.has_any_role? :admin, :volunteer, :contributor %>
-
 <div class="row">
   <div class="col-md-12">
-<%= form_for @article, html: {class: "form-horizontal"} do |f| %>
+    <%= form_for @article, html: {class: "form-horizontal"} do |f| %>
 
-  <% if @article.errors.any? %>
-  <div id="error_explanation">
-    <h2><%= pluralize(@article.errors.count, "error") %> prohibited
-      this photo from being saved:</h2>
-    <ul>
-    <% @article.errors.full_messages.each do |msg| %>
-      <li><%= msg %></li>
+    <% if @article.errors.any? %>
+      <div id="error_explanation">
+        <h2><%= pluralize(@article.errors.count, "error") %> prohibited
+        this photo from being saved:</h2>
+        <ul>
+          <% @article.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+          <% end %>
+        </ul>
+      </div>
     <% end %>
-    </ul>
-  </div>
-  <% end %>
 
-  <div class="form-group">
-    <%= f.label :language_id, "Language", class: "control-label col-sm-3" %>
-    <div class="col-sm-3">
-      <% if current_user.has_any_role? :admin, :volunteer %>
+    <div class="form-group">
+      <%= f.label :language_id, "Language", class: "control-label col-sm-3" %>
+      <div class="col-sm-3">
+        <% if current_user.has_any_role? :admin, :volunteer %>
         <%= f.collection_select(:language_id, Language.all, :id, :name ) %>
-      <% elsif current_user.has_role? :contributor %>
+        <% elsif current_user.has_role? :contributor %>
         <%= f.collection_select(:language_id, Language.where("name = ?", current_user.lang), :id, :name) %>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="form-group">
+      <%= f.label :category, class: "control-label col-sm-3" %>
+      <div class="col-sm-3">
+        <%= f.text_field :category, class: "form-control" %>
+      </div>
+    </div>
+
+    <div class="form-group">
+      <%= f.label :english, "English Text", class: "control-label col-sm-3" %>
+      <div class="col-sm-3">
+        <%= f.text_field :english, class: "form-control" %>
+      </div>
+    </div>
+
+    <div class="form-group">
+      <%= f.label :phonetic, "Phonetic Text", class: "control-label col-sm-3" %>
+      <div class="col-sm-3">
+        <%= f.text_field :phonetic, class: "form-control" %>
+      </div>
+    </div>
+
+    <div class="form-group">
+      <%= f.label :picture, class: "control-label col-sm-3" %>
+      <div class="col-sm-3">
+        <%= image_tag(@article.picture_url, :width => 400) if @article.picture.present? %>
+        <%= f.file_field :picture %> 
+      </div>
+
+      <% if @article.picture.present? %>
+      <span class="help-inline">( If you wish to change the picture, click on browse and upload the new file.)</span>
       <% end %>
     </div>
-  </div>
 
-  <div class="form-group">
-    <%= f.label :category, class: "control-label col-sm-3" %>
-    <div class="col-sm-3">
-      <%= f.text_field :category, class: "form-control" %>
-    </div>
-  </div>
-
-  <div class="form-group">
-    <%= f.label :english, "English Text", class: "control-label col-sm-3" %>
-    <div class="col-sm-3">
-      <%= f.text_field :english, class: "form-control" %>
-    </div>
-  </div>
- 
-  <div class="form-group">
-    <%= f.label :phonetic, "Phonetic Text", class: "control-label col-sm-3" %>
-    <div class="col-sm-3">
-      <%= f.text_field :phonetic, class: "form-control" %>
-    </div>
-  </div>
-
-  <div class="form-group">
-    <%= f.label :picture, class: "control-label col-sm-3" %>
-    <div class="col-sm-3">
-      <%= image_tag(@article.picture_url, :width => 400) if @article.picture.present? %>
-      <%= f.file_field :picture %> 
+    <div class="form-group form-actions">
+      <div class="col-sm-offset-3 col-sm-3">
+        <button class="btn btn-primary" type="submit">Create Article</button>
+      </div>
     </div>
 
-    <% if @article.picture.present? %>
-      <span class="help-inline">( If you wish to change the picture, click on browse and upload the new file.)</span>
     <% end %>
   </div>
-
-  <div class="form-group form-actions">
-    <div class="col-sm-offset-3 col-sm-3">
-      <button class="btn btn-primary" type="submit">Create Article</button>
-    </div>
-  </div>
-
-<% end %>
-    </div>
-  </div>
-
+</div>
 <%# end %>
 <%# end %>

--- a/app/views/articles/edit.html.erb
+++ b/app/views/articles/edit.html.erb
@@ -1,5 +1,4 @@
-
-<% if current_user.login_approval == 'Yes' %>
+<% if current_user.login_approval_at %>
 <% if current_user.has_any_role? :admin, :volunteer, :contributor %>
 <h1>Editing photo</h1>
  

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,4 +1,4 @@
-<%# if current_user.login_approval == 'Yes' %>
+<%# if current_user.login_approval_at %>
 <%# if current_user.has_any_role? :admin, :volunteer %>
 
 <h2>Listing photos</h2>
@@ -15,9 +15,9 @@
     <th colspan="2"></th>
   </tr>
  
-    <div id="articles">
-      <%= render partial: 'article', collection: @articles %>
-    </div>
+  <div id="articles">
+    <%= render partial: 'article', collection: @articles %>
+  </div>
 </table>
 
 <%= will_paginate @articles %>
@@ -28,41 +28,45 @@
 
 
 <% if current_user.has_role? :contributor %>
-<% if current_user.lang == nil %> <!-- do nothing as 1 contributor can contribute to 1 language only -->
+<% if current_user.lang == nil %> 
+  <!-- do nothing as 1 contributor can contribute to 1 language only -->
 <% else %>
 
 <h1>Listing photos for <%= current_user.lang %> language</h1>
 <p><u><b><%= link_to '+New photo', new_article_path %></b></u></p>
  
 <ol>
-<% @articles.each do |article| %>
-<% if article.language.present? %>
-<% if article.language.name == current_user.lang %>
-<li>
-<p>
-  <strong>Picture:</strong>
-  <%= image_tag(article.picture_url, :width => 400) if article.picture.present? %>
-</p>
-<p>
-  <strong>Phonetic Text:</strong>
-  <%= article.phonetic %>
-</p>
-<p>
-  <strong>English Text:</strong>
-  <%= article.english %>
-</p> 
-<p>
-  <strong>Category:</strong>
-  <%= article.category %>
-</p>
-<p><%= link_to 'Show', article_path(article) %>
-<%= link_to 'Edit', edit_article_path(article) %></p>
-<hr/>
-<% end %>
-<% end %>
-<% end %>
+  <% @articles.each do |article| %>
+    <% if article.language.present? %>
+      <% if article.language.name == current_user.lang %>
+        <li>
+          <p>
+            <strong>Picture:</strong>
+            <%= image_tag(article.picture_url, :width => 400) if article.picture.present? %>
+          </p>
+          <p>
+            <strong>Phonetic Text:</strong>
+            <%= article.phonetic %>
+          </p>
+          <p>
+            <strong>English Text:</strong>
+            <%= article.english %>
+          </p> 
+          <p>
+            <strong>Category:</strong>
+            <%= article.category %>
+          </p>
+        </li>
+        <%= link_to 'Show', article_path(article) %>
+        <%= link_to 'Edit', edit_article_path(article) %></p>
+        <hr/>
+      <% end %>
+    <% end %>
+  <% end %>
 </ol>
+
 <% end %>
 <% end %>
 
+<%# end %>
 <%# end %>

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -1,4 +1,4 @@
-<%# if current_user.login_approval == 'Yes' %>
+<%# if current_user.login_approval_at %>
 <%# if current_user.has_any_role? :admin, :volunteer, :contributor %>
 
 <h1>New photo</h1>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,6 +1,6 @@
-
-<%# if current_user.login_approval == 'Yes' %>
+<%# if current_user.login_approval_at %>
 <%# if current_user.has_any_role? :admin, :volunteer, :contributor %>
+
 <h1>Saved photo </h1>
 <p>
   <strong>Language:</strong>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,153 +1,148 @@
 <div class="row">
   <div class="col-md-12">
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: {method: :put, class: "form-horizontal" }) do |f| %>
-  <fieldset>
-  <legend>Edit <%= resource_name.to_s.humanize %> Profile</legend>
-  <%= devise_error_messages! %>
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: {method: :put, class: "form-horizontal" }) do |f| %>
+    <fieldset>
+    <legend>Edit <%= resource_name.to_s.humanize %> Profile</legend>
+    <%= devise_error_messages! %>
 
-  <div class="form-group">
-    <%= f.label :username, class: "control-label col-sm-3" %>
-    <div class="col-sm-3">
-      <%= f.text_field :username, class: "form-control" %>
-    </div>
-  </div>
 
-  <div class="form-group">
-    <%= f.label :first_name, class: "control-label col-sm-3" %>
-    <div class="col-sm-3">
-      <%= f.text_field :first_name, class: "form-control" %>
+    <div class="form-group">
+      <%= f.label :email, class: "control-label col-sm-3" %>
+      <div class="col-sm-3">
+        <%= f.email_field :email, class: "form-control" %>
+      </div>
     </div>
-  </div>
 
-  <div class="form-group">
-    <%= f.label :last_name, class: "control-label col-sm-3" %>
-    <div class="col-sm-3">
-      <%= f.text_field :last_name, class: "form-control" %>
+    <div class="form-group">
+      <%= f.label :username, class: "control-label col-sm-3" %>
+      <div class="col-sm-3">
+        <%= f.text_field :username, class: "form-control" %>
+      </div>
     </div>
-  </div>
+
+    <div class="form-group">
+      <%= f.label :first_name, class: "control-label col-sm-3" %>
+      <div class="col-sm-3">
+        <%= f.text_field :first_name, class: "form-control" %>
+      </div>
+    </div>
+
+    <div class="form-group">
+      <%= f.label :last_name, class: "control-label col-sm-3" %>
+      <div class="col-sm-3">
+        <%= f.text_field :last_name, class: "form-control" %>
+      </div>
+    </div>
 
 <!-- TODO: Another method for changing roles are needed -->
 
-  <div class="form-group">
-    <%= f.label :gender, class: "control-label col-sm-3" %>
-    <div class="col-sm-3">
-      <label>
-        <%= f.radio_button :gender, 'Male', checked:true %> Male
-      </label>
-      <label>
-        <%= f.radio_button :gender, 'Female' %> Female
-      </label>
+    <div class="form-group">
+      <%= f.label :gender, class: "control-label col-sm-3" %>
+      <div class="col-sm-3">
+        <label>
+          <%= f.radio_button :gender, 'Male', checked:true %> Male
+        </label>
+        <label>
+          <%= f.radio_button :gender, 'Female' %> Female
+        </label>
+      </div>
     </div>
-  </div>
 
-  <div class="form-group">
-    <%= f.label :email, class: "control-label col-sm-3" %>
-    <div class="col-sm-3">
-      <%= f.email_field :email, class: "form-control" %>
+    <div class="form-group">
+      <%= f.label :location, class: "control-label col-sm-3" %>
+      <div class="col-sm-3">
+        <%= f.collection_select(:location, Installation.all, :installation, :installation, :include_blank => "None") %>
+      </div>
     </div>
-  </div>
 
-  <div class="form-group">
-    <%= f.label :location, class: "control-label col-sm-3" %>
-    <div class="col-sm-3">
-      <%= f.collection_select(:location, Installation.all, :installation, :installation, :include_blank => "None") %>
+    <div class="form-group">
+      <%= f.label :lang, "Language Contribution", class: "control-label col-sm-3" %>
+      <div class="col-sm-3">
+        <%= f.collection_select(:lang, Language.all, :name, :name, :include_blank => "All") %>
+      </div>
     </div>
-  </div>
 
-  <div class="form-group">
-    <%= f.label :lang, "Language Contribution", class: "control-label col-sm-3" %>
-    <div class="col-sm-3">
-      <%= f.collection_select(:lang, Language.all, :name, :name, :include_blank => "All") %>
+    <div class="form-group">
+      <%= f.label :contact, "Contact Number", class: "control-label col-sm-3" %>
+      <div class="col-sm-3">
+        <%= f.text_field :contact, class: "form-control" %>
+      </div>
     </div>
-  </div>
 
-  <div class="form-group">
-    <%= f.label :contact, "Contact Number", class: "control-label col-sm-3" %>
-    <div class="col-sm-3">
-      <%= f.text_field :contact, class: "form-control" %>
+    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+      <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+    <% end %>
+    <br/>
+
+    <hr />
+    <div class="form-group">
+      <span class="help-inline">Fill out the following fields only if you wish to change your password.</span>
     </div>
-  </div>
 
-  <div class="form-group">
-    <%= f.label :Login_Approval, "Login Approval (cannot change)", class: "control-label col-sm-3" %>
-    <div class="col-sm-3">
-      <%= f.radio_button :login_approval, @user.login_approval, checked:true %> 
-      <%= label :login_approval, @user.login_approval %>
+    <div class="form-group">
+      <%= f.label :password, class: "control-label col-sm-3" %>
+      <div class="col-sm-3">
+        <%= f.password_field :password, class: "form-control" %>
+      </div>
     </div>
-  </div>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+    <div class="form-group">
+      <%= f.label :password_confirmation, class: "control-label col-sm-3" %>
+      <div class="col-sm-3">
+        <%= f.password_field :password_confirmation, class: "form-control" %>
+      </div>
+    </div>
+
+    <div class="form-group">
+      <div>
+        <%= f.label :current_password, class: "control-label col-sm-3" %>
+        <div class="col-sm-3">
+          <%= f.password_field :current_password, class: "form-control" %>
+        </div>
+        <span class="help-inline">( If you don't want to change your username or password then leave this field blank. )</span>
+      </div>
+    </div>
+
+    <div class="form-group form-actions">
+      <div class="col-sm-offset-3 col-sm-3">
+        <button class="btn btn-primary" type="submit">Update</button>
+      </div>
+    </div>
+
+    </fieldset>
   <% end %>
-  <br/>
 
   <hr />
-  <div class="form-group">
-    <span class="help-inline">Fill out the following fields only if you wish to change your password.</span>
-  </div>
 
-  <div class="form-group">
-    <%= f.label :password, class: "control-label col-sm-3" %>
-    <div class="col-sm-3">
-      <%= f.password_field :password, class: "form-control" %>
-    </div>
-  </div>
+  <h3>API key</h3>
 
-  <div class="form-group">
-    <%= f.label :password_confirmation, class: "control-label col-sm-3" %>
-    <div class="col-sm-3">
-      <%= f.password_field :password_confirmation, class: "form-control" %>
-    </div>
-  </div>
+  <div class="api_key">
 
-  <div class="form-group">
-    <div>
-      <%= f.label :current_password, class: "control-label col-sm-3" %>
+    <fieldset>
+    <div class="form-group">
       <div class="col-sm-3">
-        <%= f.password_field :current_password, class: "form-control" %>
+        <p rows="1" onclick="this.focus();this.select()" class="form-control">
+          <%= current_user.authentication_token %>
+        </p>
       </div>
-      <span class="help-inline">( If you don't want to change your username or password then leave this field blank. )</span>
     </div>
+    </fieldset>
+
+    <span class="help-inline"><%= link_to "Regenerate", users_regenerate_api_key_path, method: :post %></span>
+    </ul>
   </div>
 
-  <div class="form-group form-actions">
-    <div class="col-sm-offset-3 col-sm-3">
-      <button class="btn btn-primary" type="submit">Update</button>
-    </div>
-  </div>
-
-  </fieldset>
-<% end %>
-
-<hr />
-
-<h3>API key</h3>
-
-<div class="api_key">
+  <hr />
+  <h3>Cancel my account</h3>
 
   <fieldset>
-  <div class="form-group">
-    <div class="col-sm-3">
-      <p rows="1" onclick="this.focus();this.select()" class="form-control">
-        <%= current_user.authentication_token %>
-      </p>
+    <div class="form-group">
+      <div>
+        <p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete, class: "btn btn-danger" %></p>
+      </div>
     </div>
-  </div>
   </fieldset>
 
-  <span class="help-inline"><%= link_to "Regenerate", users_regenerate_api_key_path, method: :post %></span>
-  </ul>
-</div>
-
-<hr />
-<h3>Cancel my account</h3>
-
-<fieldset>
-
-  <div class="form-group">
-    <div>
-      <p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete, class: "btn btn-danger" %></p>
-    </div>
   </div>
-</fieldset>
+</div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -8,6 +8,13 @@
       <%= devise_error_messages! %>
 
       <div class="form-group">
+        <%= f.label :email, class: "control-label col-sm-3" %>
+        <div class="col-sm-3">
+          <%= f.text_field :email, class: "form-control" %>
+        </div>
+      </div>
+
+      <div class="form-group">
         <%= f.label :username, class: "control-label col-sm-3" %>
         <div class="col-sm-3">
           <%= f.text_field :username, class: "form-control" %>
@@ -49,11 +56,6 @@
         <div class="col-sm-3">
           <%= f.password_field :password_confirmation, class: "form-control" %>
         </div>
-      </div>
-
-      <div hidden><%= f.label :Can_you_login_with_the_registered_role_? %> &nbsp;
-      <%= f.radio_button :login_approval, 'Not Yet', checked:true %> 
-      <%= label :login_approval_not_yet, 'Not Yet' %>
       </div>
 
       <div class="form-group form-actions">

--- a/app/views/installations/_form.html.erb
+++ b/app/views/installations/_form.html.erb
@@ -1,20 +1,19 @@
-
-<% if current_user.login_approval == 'Yes' %>
+<% if current_user.login_approval_at %>
 <% if current_user.has_role? :admin %>
-
 <div class="row">
   <div class="col-md-12">
-<%= form_for @installation, html: {class: "form-horizontal"} do |f| %>
-  <% if @installation.errors.any? %>
-    <div id="error_explanation">
+    <%= form_for @installation, html: {class: "form-horizontal"} do |f| %>
+
+    <% if @installation.errors.any? %>
+      <div id="error_explanation">
         <h2><%= pluralize(@installation.errors.count, "error") %> prohibited this post contact information from being saved:</h2>
-	     <ul>
-		 <% @installation.errors.full_messages.each do |msg| %>
-		        <li><%= msg %></li>
-	         <% end %>
-	     </ul>
-     </div>
-   <% end %>
+        <ul>
+          <% @installation.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
 
     <div class="form-group">
       <%= f.label :installation, "Post", class: "control-label col-sm-3" %>
@@ -49,8 +48,8 @@
         <button class="btn btn-primary" type="submit">Create Post</button>
       </div>
     </div>
-<% end %>
 
+    <% end %>
   </div>
 </div>
 <% end %>

--- a/app/views/installations/edit.html.erb
+++ b/app/views/installations/edit.html.erb
@@ -1,5 +1,4 @@
-
-<% if current_user.login_approval == 'Yes' %>
+<% if current_user.login_approval_at %>
 <% if current_user.has_role? :admin %>
 <h1>Editing post contact information</h1>
  

--- a/app/views/installations/new.html.erb
+++ b/app/views/installations/new.html.erb
@@ -1,5 +1,4 @@
-
-<% if current_user.login_approval == 'Yes' %>
+<% if current_user.login_approval_at %>
 <% if current_user.has_role? :admin %>
 <h2>New post contact information</h2>
 <hr />

--- a/app/views/installations/show.html.erb
+++ b/app/views/installations/show.html.erb
@@ -1,11 +1,13 @@
-
-<% if current_user.login_approval == 'Yes' %>
+<% if current_user.login_approval_at %>
 <% if current_user.has_role? :admin %>
+
 <h1>Saved post contact information</h1>
+
 <p>
   <strong>Post:</strong>
   <%= @installation.installation %>
 </p>
+
 <p>
   <strong>Email Id:</strong>
   <%= @installation.email %>
@@ -21,14 +23,19 @@
   <%= @installation.contact %>
 </p>
 
-<p><strong>Sites:</strong><ol>
-<% @installation.sites.each do |site| %>
-  <li>
-          <%= site.name %>
-  </li>	     
-<% end %></ol></p>
+<p>
+  <strong>Sites:</strong>
+  <ol>
+    <% @installation.sites.each do |site| %>
+    <li>
+      <%= site.name %>
+    </li>	     
+    <% end %>
+  </ol>
+</p>
 
 <%= link_to 'Back', installations_path %>
 <%= link_to 'Edit', edit_installation_path(@installation) %>
+
 <% end %>
 <% end %>

--- a/app/views/languages/_form.html.erb
+++ b/app/views/languages/_form.html.erb
@@ -1,38 +1,36 @@
-<%# if current_user.login_approval == 'Yes' %>
+<%# if current_user.login_approval_at %>
 <%# if current_user.has_role? :admin %>
-
 <div class="row">
   <div class="col-md-12">
-<%= form_for @language, html: {class: "form-horizontal"} do |f| %>
+    <%= form_for @language, html: {class: "form-horizontal"} do |f| %>
 
-  <% if @language.errors.any? %>
-  <div id="error_explanation">
-    <h2><%= pluralize(@language.errors.count, "error") %> prohibited
-      this language from being saved:</h2>
-    <ul>
-    <% @language.errors.full_messages.each do |msg| %>
-      <li><%= msg %></li>
+    <% if @language.errors.any? %>
+      <div id="error_explanation">
+        <h2><%= pluralize(@language.errors.count, "error") %> prohibited
+        this language from being saved:</h2>
+        <ul>
+          <% @language.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+          <% end %>
+        </ul>
+      </div>
     <% end %>
-    </ul>
-  </div>
-  <% end %>
 
-  <div class="form-group">
-    <%= f.label :name, class: "control-label col-sm-3" %>
-    <div class="col-sm-3">
-      <%= f.text_field :name, class: "form-control" %>
+    <div class="form-group">
+      <%= f.label :name, class: "control-label col-sm-3" %>
+      <div class="col-sm-3">
+        <%= f.text_field :name, class: "form-control" %>
+      </div>
     </div>
-  </div>
 
-  <div class="form-group form-actions">
-    <div class="col-sm-offset-3 col-sm-3">
-      <button class="btn btn-primary" type="submit">Create Language</button>
+    <div class="form-group form-actions">
+      <div class="col-sm-offset-3 col-sm-3">
+        <button class="btn btn-primary" type="submit">Create Language</button>
+      </div>
     </div>
-  </div>
-<% end %>
 
+    <% end %>
   </div>
 </div>
-
 <%# end %>
 <%# end %>

--- a/app/views/languages/edit.html.erb
+++ b/app/views/languages/edit.html.erb
@@ -1,5 +1,4 @@
-
-<% if current_user.login_approval == 'Yes' %>
+<% if current_user.login_approval_at %>
 <% if current_user.has_role? :admin %>
 <h1>Editing language</h1>
  

--- a/app/views/languages/index.html.erb
+++ b/app/views/languages/index.html.erb
@@ -1,24 +1,26 @@
-<%# if current_user.login_approval == 'Yes' %>
+<%# if current_user.login_approval_at %>
 <%# if current_user.has_any_role? :admin, :volunteer, :contributor %>
 <h1>Listing Languages</h1>
  
 <table class="table table-striped">
   <tr>
     <th>Name</th>
-<% if current_user.has_role? :admin %>
+    <% if current_user.has_role? :admin %>
     <th colspan="2"></th>
-<% else %>
+    <% else %>
     <th colspan="1"></th>
-<% end %>
+    <% end %>
   </tr>
   <% @languages.each do |language| %>
     <tr>
       <td><%= language.name %></td>
       <td><%= link_to 'Photos', language_path(language) %></td>
-<% if current_user.has_role? :admin %>
-      <td><%= link_to 'Edit', edit_language_path(language) %>
-      <%= link_to 'Delete', language_path(language), method: :delete, class: "btn btn-danger btn-xs", data: { confirm: 'Are you sure?' } %></td>
-<% end %>
+      <% if current_user.has_role? :admin %>
+        <td>
+          <%= link_to 'Edit', edit_language_path(language) %>
+          <%= link_to 'Delete', language_path(language), method: :delete, class: "btn btn-danger btn-xs", data: { confirm: 'Are you sure?' } %>
+        </td>
+      <% end %>
     </tr>
   <% end %>
 </table>

--- a/app/views/languages/new.html.erb
+++ b/app/views/languages/new.html.erb
@@ -1,6 +1,6 @@
 <!-- Welcome -->
 
-<%# if current_user.login_approval == 'Yes' %>
+<%# if current_user.login_approval_at %>
 <%# if current_user.has_role? :admin %>
 
 <h1>New language</h1>

--- a/app/views/languages/show.html.erb
+++ b/app/views/languages/show.html.erb
@@ -1,28 +1,32 @@
-
-<% if current_user.login_approval == 'Yes' %>
+<% if current_user.login_approval_at %>
 <% if current_user.has_any_role? :admin, :volunteer, :contributor %>
+
 <h1>Photos under <%= @language.name %> language </h1>
 <br/>
 <ol>
-<% @language.articles.each do |article| %><li>
-<p>
-  <strong>Category:</strong>
-  <%= article.category %>
-</p>
-<p>
-  <strong>English Text:</strong>
-  <%= article.english %>
-</p> 
-<p>
-  <strong>Phonetic Text:</strong>
-  <%= article.phonetic %>
-</p>
-<p>
-  <strong>Picture:</strong>
-  <%= image_tag(article.picture_url, :width => 600) if article.picture.present? %>
-</p>
-<% end %></ol>
+  <% @language.articles.each do |article| %>
+  <li>
+  	<p>
+  	  <strong>Category:</strong>
+  	  <%= article.category %>
+  	</p>
+  	<p>
+  	  <strong>English Text:</strong>
+  	  <%= article.english %>
+  	</p> 
+  	<p>
+  	  <strong>Phonetic Text:</strong>
+  	  <%= article.phonetic %>
+  	</p>
+  	<p>
+  	  <strong>Picture:</strong>
+  	  <%= image_tag(article.picture_url, :width => 600) if article.picture.present? %>
+  	</p>
+  </li>
+  <% end %>
+</ol>
 
 <%= link_to 'Back', languages_path %>
+
 <% end %>
 <% end %>

--- a/app/views/sites/_form.html.erb
+++ b/app/views/sites/_form.html.erb
@@ -1,21 +1,20 @@
-
-<% if current_user.login_approval == 'Yes' %>
+<% if current_user.login_approval_at %>
 <% if current_user.has_any_role? :admin, :volunteer %>
-
 <div class="row">
   <div class="col-md-12">
-<%= form_for @site, html: {class: "form-horizontal"} do |f| %>
-  <% if @site.errors.any? %>
-  <div id="error_explanation">
-    <h2><%= pluralize(@site.errors.count, "error") %> prohibited
-      this article from being saved:</h2>
-    <ul>
-    <% @site.errors.full_messages.each do |msg| %>
-      <li><%= msg %></li>
+    <%= form_for @site, html: {class: "form-horizontal"} do |f| %>
+
+    <% if @site.errors.any? %>
+      <div id="error_explanation">
+        <h2><%= pluralize(@site.errors.count, "error") %> prohibited
+        this article from being saved:</h2>
+        <ul>
+          <% @site.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+          <% end %>
+        </ul>
+      </div>
     <% end %>
-    </ul>
-  </div>
-  <% end %>
 
     <div class="form-group">
       <%= f.label :installation_id, "Post", class: "control-label col-sm-3" %>
@@ -24,21 +23,21 @@
       </div>
     </div>
 
-  <div class="form-group">
-    <%= f.label :name, "Site", class: "control-label col-sm-3" %>
-    <div class="col-sm-3">
-      <%= f.text_field :name, class: "form-control" %>
+    <div class="form-group">
+      <%= f.label :name, "Site", class: "control-label col-sm-3" %>
+      <div class="col-sm-3">
+        <%= f.text_field :name, class: "form-control" %>
+      </div>
     </div>
-  </div>
 
 
-  <div class="form-group form-actions">
-    <div class="col-sm-offset-3 col-sm-3">
-      <button class="btn btn-primary" type="submit">Create Site</button>
+    <div class="form-group form-actions">
+      <div class="col-sm-offset-3 col-sm-3">
+        <button class="btn btn-primary" type="submit">Create Site</button>
+      </div>
     </div>
-  </div>
-<% end %>
 
+    <% end %>
   </div>
 </div>
 <% end %>

--- a/app/views/sites/edit.html.erb
+++ b/app/views/sites/edit.html.erb
@@ -1,5 +1,4 @@
-
-<% if current_user.login_approval == 'Yes' %>
+<% if current_user.login_approval_at %>
 <% if current_user.has_any_role? :admin, :volunteer %>
 <h1>Editing site</h1>
  

--- a/app/views/sites/new.html.erb
+++ b/app/views/sites/new.html.erb
@@ -1,5 +1,4 @@
-
-<% if current_user.login_approval == 'Yes' %>
+<% if current_user.login_approval_at %>
 <% if current_user.has_role? :admin %>
 <h1>New site</h1>
  

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -1,60 +1,73 @@
-
-<% if current_user.login_approval == 'Yes' %>
+<% if current_user.login_approval_at %>
 <% if current_user.has_any_role? :admin, :volunteer %>
+
 <h1>Saved site information</h1>
+
 <p>
   <strong>Post:</strong>
   <%= @site.installation.installation %>
 </p>
+
 <p>
   <strong>Site name:</strong>
   <%= @site.name %>
 </p>
-<p><strong>Volunteers:</strong><ol>
-<% @site.volunteers.each do |volunteer| %>
-  <li>
-          <%= volunteer.vname %>&nbsp;
-<% if current_user.has_role? :admin %>
-	  <%= link_to 'Delete', [volunteer.site, volunteer], method: :delete, data: { confirm: 'Are you sure?' } %>
-<% end %>
-  </li>	     
-<% end %></ol></p>
+
+<p>
+  <strong>Volunteers:</strong>
+  <ol>
+    <% @site.volunteers.each do |volunteer| %>
+    <li>
+      <%= volunteer.vname %>&nbsp;
+      <% if current_user.has_role? :admin %>
+      <%= link_to 'Delete', [volunteer.site, volunteer], method: :delete, data: { confirm: 'Are you sure?' } %>
+      <% end %>
+    </li>
+    <% end %>
+  </ol>
+</p>
 
 <% if current_user.has_role? :admin %>
-<h2>Add a volunteer name:</h2>
-<%= form_for([@site, @site.volunteers.build]) do |f| %>
-  <% if @site.volunteers.build.errors.any? %>
+  <h2>Add a volunteer name:</h2>
+  <%= form_for([@site, @site.volunteers.build]) do |f| %>
+    <% if @site.volunteers.build.errors.any? %>
+    <% end %>
+    <p>
+	    <%= f.label :Volunteer_Name %><br>
+	    <%= f.text_field :vname %>
+    </p>
+    <p>
+	    <%= f.submit %>
+    </p>
   <% end %>
-   <p>
-	<%= f.label :Volunteer_Name %><br>
-	<%= f.text_field :vname %>
-   </p>
-   <p>
-	<%= f.submit %>
-   </p>
-<% end %>
 <% end %>
 
-<p><strong>Contributors:</strong><ol>
-<% @site.contributors.each do |contributor| %>
-  <li>
-          <%= contributor.name %>&nbsp;<%= link_to 'Delete', [contributor.site, contributor], method: :delete, data: { confirm: 'Are you sure?' } %>
-  </li>	     
-<% end %></ol></p>
+<p>
+  <strong>Contributors:</strong>
+  <ol>
+    <% @site.contributors.each do |contributor| %>
+    <li>
+      <%= contributor.name %>&nbsp;<%= link_to 'Delete', [contributor.site, contributor], method: :delete, data: { confirm: 'Are you sure?' } %>
+    </li>	     
+    <% end %>
+  </ol>
+</p>
 
 <h2>Add a contributor name:</h2>
 <%= form_for([@site, @site.contributors.build]) do |f| %>
   <% if @site.contributors.build.errors.any? %>
   <% end %>
-   <p>
-	<%= f.label :Contributor_Name %><br>
-	<%= f.text_field :name %>
-   </p>
-   <p>
-	<%= f.submit %>
-   </p>
+  <p>
+  	<%= f.label :Contributor_Name %><br>
+  	<%= f.text_field :name %>
+  </p>
+  <p>
+  	<%= f.submit %>
+  </p>
 <% end %>
+
 <%= link_to 'Back', sites_path %>
 <%= link_to 'Edit', edit_site_path(@site) %>
+
 <% end %>
 <% end %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,92 +1,83 @@
 <div class="row">
   <div class="col-md-12">
+    <%= form_for @user, html: { class: "form-horizontal" } do |f| %>
 
-<%= form_for @user, html: { class: "form-horizontal" } do |f| %>
-
-  <% if @user.errors.any? %>
-
-  <div id="error_explanation">
-    <h2><%= pluralize(@user.errors.count, "error") %> prohibited
-      this volunteer contact information from being saved:</h2>
-    <ul>
-    <% @user.errors.full_messages.each do |msg| %>
-      <li><%= msg %></li>
+    <% if @user.errors.any? %>
+      <div id="error_explanation">
+        <h2><%= pluralize(@user.errors.count, "error") %> prohibited
+        this volunteer contact information from being saved:</h2>
+        <ul>
+          <% @user.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+          <% end %>
+        </ul>
+      </div>
     <% end %>
-    </ul>
-  </div>
-  <% end %>
 
-  <div class="form-group">
-    <%= f.label :username, class: "control-label col-sm-3" %>
-    <div class="col-sm-3">
-      <%= f.text_field :username, class: "form-control" %>
+    <div class="form-group">
+      <%= f.label :username, class: "control-label col-sm-3" %>
+      <div class="col-sm-3">
+        <%= f.text_field :username, class: "form-control" %>
+      </div>
     </div>
-  </div>
-  
-  <div class="form-group">
-    <%= f.label :first_name, class: "control-label col-sm-3" %>
-    <div class="col-sm-3">
-      <%= f.text_field :first_name, class: "form-control" %>
+
+    <div class="form-group">
+      <%= f.label :first_name, class: "control-label col-sm-3" %>
+      <div class="col-sm-3">
+        <%= f.text_field :first_name, class: "form-control" %>
+      </div>
     </div>
-  </div>
 
-  <div class="form-group">
-    <%= f.label :last_name, class: "control-label col-sm-3" %>
-    <div class="col-sm-3">
-      <%= f.text_field :last_name, class: "form-control" %>
+    <div class="form-group">
+      <%= f.label :last_name, class: "control-label col-sm-3" %>
+      <div class="col-sm-3">
+        <%= f.text_field :last_name, class: "form-control" %>
+      </div>
     </div>
-  </div>
 
-<!-- TODO: Roles are to be set elsewhere -->
+    <!-- TODO: Roles are to be set elsewhere -->
 
-  <div class="form-group">
-    <%= f.label :login_approval, class: "control-label col-sm-3" %>
-    <div class="col-sm-3">
-      <%= f.select :login_approval, options_for_select([[@user.login_approval, @user.login_approval], ['Yes' ,'Yes'], ['Not Yet', 'Not Yet']]) %>
+    <div class="form-group">
+      <%= f.label :email, class: "control-label col-sm-3" %>
+      <div class="col-sm-3">
+        <%= f.email_field :email, class: "form-control" %>
+      </div>
     </div>
-  </div>
 
-  <div class="form-group">
-    <%= f.label :email, class: "control-label col-sm-3" %>
-    <div class="col-sm-3">
-      <%= f.email_field :email, class: "form-control" %>
+    <div class="form-group">
+      <%= f.label :location, class: "control-label col-sm-3" %>
+      <div class="col-sm-3">
+        <%= f.collection_select(:location, Installation.all, :installation, :installation, :include_blank => "None") %>
+      </div>
     </div>
-  </div>
 
-  <div class="form-group">
-    <%= f.label :location, class: "control-label col-sm-3" %>
-    <div class="col-sm-3">
-      <%= f.collection_select(:location, Installation.all, :installation, :installation, :include_blank => "None") %>
+    <div class="form-group">
+      <%= f.label :lang, "Language Contribution", class: "control-label col-sm-3" %>
+      <div class="col-sm-3">
+        <%= f.collection_select(:lang, Language.all, :name, :name, :include_blank => "All") %>
+      </div>
     </div>
-  </div>
 
-  <div class="form-group">
-    <%= f.label :lang, "Language Contribution", class: "control-label col-sm-3" %>
-    <div class="col-sm-3">
-      <%= f.collection_select(:lang, Language.all, :name, :name, :include_blank => "All") %>
+    <div class="form-group">
+      <%= f.label :contact, "Contact Number", class: "control-label col-sm-3" %>
+      <div class="col-sm-3">
+        <%= f.text_field :contact, class: "form-control" %>
+      </div>
     </div>
-  </div>
 
-  <div class="form-group">
-    <%= f.label :contact, "Contact Number", class: "control-label col-sm-3" %>
-    <div class="col-sm-3">
-      <%= f.text_field :contact, class: "form-control" %>
+    <div class="form-group">
+      <%= f.label :gender, class: "control-label col-sm-3" %>
+      <div class="col-sm-3">
+        <%= f.select :gender, options_for_select([[@user.gender, @user.gender], ['Male', 'le'], ['Female' ,'Female'],]) %>
+      </div>
+    </div>     
+
+    <div class="form-group form-actions">
+      <div class="col-sm-offset-3 col-sm-3">
+        <button class="btn btn-primary" type="submit">Update</button>
+      </div>
     </div>
-  </div>
 
-  <div class="form-group">
-    <%= f.label :gender, class: "control-label col-sm-3" %>
-    <div class="col-sm-3">
-      <%= f.select :gender, options_for_select([[@user.gender, @user.gender], ['Male', 'Male'], ['Female' ,'Female'],]) %>
-     </div>
-  </div>     
-
-  <div class="form-group form-actions">
-    <div class="col-sm-offset-3 col-sm-3">
-      <button class="btn btn-primary" type="submit">Update</button>
-    </div>
-  </div>
-
-<% end %>
+    <% end %>
   </div>
 </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,35 +1,3 @@
-<h3><%= t("Members") %></h3>
-
 <%= render partial: "search_form" %>
 
-<table class="table table-striped">
-  <tr>
-    <th>Name</th>
-    <th>Username</th>
-    <th>Gender</th>
-    <th>Email</th>
-    <th>Location</th>
-    <th>Language</th>
-    <th>Mobile</th>
-    <th>Login Approval</th>
-    <th colspan="3"></th>
-  </tr>
- 
-  <% @users.each do |user| %>
-    <tr>
-      <td><%= "#{user.first_name} #{user.last_name}" %></td>
-      <td><%= user.username %></td>
-      <td><%= user.gender %></td>
-      <td><%= user.email %></td>
-      <td><%= user.location %></td>
-      <td><%= user.lang %></td>
-      <td><%= user.contact %></td>
-      <td><%= user.login_approval_at %></td>
-      <td><%= link_to 'Show', user_path(user) %></td>
-      <td><%= link_to 'Edit', edit_user_path(user) %></td>
-      <td><%= link_to 'Delete', user_path(user), method: :delete, data: { confirm: 'Are you sure?' } %></td>
-    </tr>
-  <% end %>
-</table>
-
-<%= will_paginate @users %>
+<%= react_component 'UsersIndexBox', {data:@users} %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -24,7 +24,7 @@
       <td><%= user.location %></td>
       <td><%= user.lang %></td>
       <td><%= user.contact %></td>
-      <td><%= user.login_approval %></td>
+      <td><%= user.login_approval_at %></td>
       <td><%= link_to 'Show', user_path(user) %></td>
       <td><%= link_to 'Edit', edit_user_path(user) %></td>
       <td><%= link_to 'Delete', user_path(user), method: :delete, data: { confirm: 'Are you sure?' } %></td>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,5 +1,4 @@
-
-<% if current_user.login_approval == 'Yes' %>
+<% if current_user.login_approval_at %>
 <% if current_user.has_role? :admin %>
 
 <h1>New volunteer contact information</h1>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -22,8 +22,9 @@
   <dt>Contact Number</dt>
   <dd><%= @user.contact %></dd>
 
-  <dt>Login Approval</dt>
-  <dd><%= @user.login_approval %></dd>
+  <% if !@user.login_approval_at %>
+    <dd><b>The user first needs to be approved to use the account.</b></dd>
+  <% end %>
 </dl>
 
 <%= link_to 'Edit', edit_user_path(@user) %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -24,16 +24,16 @@
   <dt>Contact Number</dt>
   <dd><%= current_user.contact %></dd>
 
-  <dt>Login Approval</dt>
-  <dd><%= current_user.login_approval %></dd>
+  <% if !current_user.login_approval_at %>
+    <dd><b>You first need to be approved to use your account. Ask your administrator for an approval.</b></dd>
+  <% end %>
 </dl>
 
 <hr/>
 
 <% else %>
+
 <h3>Please login to use this application.</h3>
 <h3>If you are a new user the please sign up.</h3>
+
 <% end %>
-
-
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Rails.application.routes.draw do
   #  - for admin to edit the user table records other than username or password without knowing the password.
 
   resources :users, path: :members
+  post "members/approve", to: "users#approve_user"
+  post "members/disapprove", to: "users#disapprove_user"
 
   devise_scope :user do
     post  "users/regenerate_api_key", to: "registrations#regenerate_api_key"

--- a/db/migrate/20150701125539_change_login_approval_from_string_to_datetime.rb
+++ b/db/migrate/20150701125539_change_login_approval_from_string_to_datetime.rb
@@ -1,0 +1,13 @@
+class ChangeLoginApprovalFromStringToDatetime < ActiveRecord::Migration
+  def change
+    add_column :users, :login_approval_at, :datetime
+
+    User.reset_column_information
+    User.all.each do |user|
+      user.login_approval_at = user.login_approval == 'Yes' ? Time.now : nil
+      user.save
+    end
+
+    remove_column :users, :login_approval, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150623101358) do
+ActiveRecord::Schema.define(version: 20150701125539) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -93,10 +93,10 @@ ActiveRecord::Schema.define(version: 20150623101358) do
     t.string   "location"
     t.string   "contact"
     t.string   "gender"
-    t.string   "login_approval"
     t.string   "lang"
     t.tsvector "tsv_data"
     t.string   "authentication_token"
+    t.datetime "login_approval_at"
   end
 
   add_index "users", ["authentication_token"], name: "index_users_on_authentication_token", unique: true, using: :btree

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,11 +8,11 @@
 
 # must be taken care of at the time of production.
 
-   user = User.create({ username: 'Admin1' , first_name: 'Adam', last_name: 'Wilkins', login_approval: 'Yes',
+   user = User.create({ username: 'Admin1' , first_name: 'Adam', last_name: 'Wilkins', login_approval_at: Time.now,
 		   password: 'admin1', password_confirmation: 'admin1', email: 'saumyagurtu@gmail.com'})
    User.find(user.id).add_role :admin
 
-   user = User.create({ username: 'Admin2' , first_name: 'Neil', last_name: 'Bohr', login_approval: 'Yes',
+   user = User.create({ username: 'Admin2' , first_name: 'Neil', last_name: 'Bohr', login_approval_at: Time.now,
 		   password: 'admin2', password_confirmation: 'admin2', email: 'saumya.gurtu@students.iiit.ac.in'})
    User.find(user.id).add_role :admin
 

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -10,7 +10,7 @@ FactoryGirl.define do  factory :role do
     password                  "testing123"
     authentication_token      { Devise.friendly_token }
     sequence(:username)       { |n| "uname_#{n}" }
-    login_approval            { "Yes" }
+    login_approval_at         { 2.weeks.ago }
   end
 
   factory :article do

--- a/test/fixtures/installations.yml
+++ b/test/fixtures/installations.yml
@@ -3,10 +3,10 @@
 # Table name: installations
 #
 #  id           :integer          not null, primary key
-#  installation :string(255)
-#  email        :string(255)
+#  installation :string
+#  email        :string
 #  address      :text
-#  contact      :string(255)
+#  contact      :string
 #  created_at   :datetime
 #  updated_at   :datetime
 #

--- a/test/fixtures/languages.yml
+++ b/test/fixtures/languages.yml
@@ -3,7 +3,7 @@
 # Table name: languages
 #
 #  id         :integer          not null, primary key
-#  name       :string(255)
+#  name       :string
 #  created_at :datetime
 #  updated_at :datetime
 #

--- a/test/fixtures/sites.yml
+++ b/test/fixtures/sites.yml
@@ -3,7 +3,7 @@
 # Table name: sites
 #
 #  id              :integer          not null, primary key
-#  name            :string(255)
+#  name            :string
 #  installation_id :integer
 #  created_at      :datetime
 #  updated_at      :datetime

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -64,7 +64,7 @@ one:
  location: nil 
  contact: nil
  gender: nil
- login_approval: Yes
+ login_approval_at: 2015-05-12 12:02:23
  lang: nil
 
 two:
@@ -77,7 +77,7 @@ two:
  location: nil 
  contact: nil
  gender: nil
- login_approval: Yes
+ login_approval_at: 2015-05-12 12:02:23
  lang: nil
 
 three:
@@ -90,7 +90,7 @@ three:
  location: nil 
  contact: nil
  gender: nil
- login_approval: Yes
+ login_approval_at: 2015-05-12 12:02:23
  lang: nil
 
 four:
@@ -103,5 +103,4 @@ four:
  location: nil 
  contact: nil
  gender: nil
- login_approval: Not Yet
  lang: nil

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -3,38 +3,28 @@
 # Table name: users
 #
 #  id                     :integer          not null, primary key
-#  encrypted_password     :string(255)      default("")
-#  reset_password_token   :string(255)
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  reset_password_token   :string
 #  reset_password_sent_at :datetime
 #  remember_created_at    :datetime
 #  sign_in_count          :integer          default(0), not null
 #  current_sign_in_at     :datetime
 #  last_sign_in_at        :datetime
-#  current_sign_in_ip     :string(255)
-#  last_sign_in_ip        :string(255)
+#  current_sign_in_ip     :string
+#  last_sign_in_ip        :string
 #  created_at             :datetime
 #  updated_at             :datetime
-#  first_name             :string(255)
-#  last_name              :string(255)
-#  email                  :string(255)
-#  username               :string(255)
-#  location               :string(255)
-#  contact                :string(255)
-#  gender                 :string(255)
-#  bk_role                :string(255)
-#  login_approval         :string(255)
-#  lang                   :string(255)
-#  role_id                :integer
+#  first_name             :string
+#  last_name              :string
+#  username               :string
+#  location               :string
+#  contact                :string
+#  gender                 :string
+#  lang                   :string
 #  tsv_data               :tsvector
-#  invitation_token       :string
-#  invitation_created_at  :datetime
-#  invitation_sent_at     :datetime
-#  invitation_accepted_at :datetime
-#  invitation_limit       :integer
-#  invited_by_id          :integer
-#  invited_by_type        :string
-#  invitations_count      :integer          default(0)
 #  authentication_token   :string
+#  login_approval_at      :datetime
 #
 
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html

--- a/test/models/article_test.rb
+++ b/test/models/article_test.rb
@@ -7,8 +7,8 @@
 #  phonetic    :text
 #  created_at  :datetime
 #  updated_at  :datetime
-#  category    :string(255)
-#  picture     :string(255)
+#  category    :string
+#  picture     :string
 #  language_id :integer
 #  tsv_data    :tsvector
 #

--- a/test/models/installation_test.rb
+++ b/test/models/installation_test.rb
@@ -3,10 +3,10 @@
 # Table name: installations
 #
 #  id           :integer          not null, primary key
-#  installation :string(255)
-#  email        :string(255)
+#  installation :string
+#  email        :string
 #  address      :text
-#  contact      :string(255)
+#  contact      :string
 #  created_at   :datetime
 #  updated_at   :datetime
 #

--- a/test/models/language_test.rb
+++ b/test/models/language_test.rb
@@ -3,7 +3,7 @@
 # Table name: languages
 #
 #  id         :integer          not null, primary key
-#  name       :string(255)
+#  name       :string
 #  created_at :datetime
 #  updated_at :datetime
 #

--- a/test/models/role_test.rb
+++ b/test/models/role_test.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: roles
+#
+#  id            :integer          not null, primary key
+#  name          :string
+#  resource_id   :integer
+#  resource_type :string
+#  created_at    :datetime
+#  updated_at    :datetime
+#
+
 require "test_helper"
 
 class RoleTest < ActiveSupport::TestCase

--- a/test/models/site_test.rb
+++ b/test/models/site_test.rb
@@ -3,7 +3,7 @@
 # Table name: sites
 #
 #  id              :integer          not null, primary key
-#  name            :string(255)
+#  name            :string
 #  installation_id :integer
 #  created_at      :datetime
 #  updated_at      :datetime

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -3,38 +3,28 @@
 # Table name: users
 #
 #  id                     :integer          not null, primary key
-#  encrypted_password     :string(255)      default("")
-#  reset_password_token   :string(255)
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  reset_password_token   :string
 #  reset_password_sent_at :datetime
 #  remember_created_at    :datetime
 #  sign_in_count          :integer          default(0), not null
 #  current_sign_in_at     :datetime
 #  last_sign_in_at        :datetime
-#  current_sign_in_ip     :string(255)
-#  last_sign_in_ip        :string(255)
+#  current_sign_in_ip     :string
+#  last_sign_in_ip        :string
 #  created_at             :datetime
 #  updated_at             :datetime
-#  first_name             :string(255)
-#  last_name              :string(255)
-#  email                  :string(255)
-#  username               :string(255)
-#  location               :string(255)
-#  contact                :string(255)
-#  gender                 :string(255)
-#  bk_role                :string(255)
-#  login_approval         :string(255)
-#  lang                   :string(255)
-#  role_id                :integer
+#  first_name             :string
+#  last_name              :string
+#  username               :string
+#  location               :string
+#  contact                :string
+#  gender                 :string
+#  lang                   :string
 #  tsv_data               :tsvector
-#  invitation_token       :string
-#  invitation_created_at  :datetime
-#  invitation_sent_at     :datetime
-#  invitation_accepted_at :datetime
-#  invitation_limit       :integer
-#  invited_by_id          :integer
-#  invited_by_type        :string
-#  invitations_count      :integer          default(0)
 #  authentication_token   :string
+#  login_approval_at      :datetime
 #
 
 require 'test_helper'

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -44,47 +44,47 @@ class UserTest < ActiveSupport::TestCase
      assert true
    end
 
-   test "should not save user without its fields username, login_approval, first_name, last_name" do
+   test "should not save user without its fields username, email, first_name, last_name" do
      user = User.new
      assert_not user.save, "Saved the user without its compulsory fields"
    end
 
+   test "should not save user without its field email" do
+     user = User.new
+     user.username='Alia'
+     user.first_name='Aliaa'
+     user.last_name='Bhatt'
+     assert_not user.save, "Saved the user without its email"
+   end
+
    test "should not save user without its field username" do
      user = User.new
-     user.login_approval='Not_Yet'
+     user.email='wonook@wonook.me'
      user.first_name='Aliaa'
      user.last_name='Bhatt'
      assert_not user.save, "Saved the user without its username"
    end
 
-   test "should not save user without its field login_approval" do
-     user = User.new
-     user.username='Alia'
-     user.first_name='Aliaa'
-     user.last_name='Bhatt'
-     assert_not user.save, "Saved the user without its login_approval"
-   end
-
    test "should not save user without its field first_name" do
      user = User.new
+     user.email='wonook@wonook.me'
      user.username='Alia'
-     user.login_approval='Not_Yet'
      user.last_name='Bhatt'
      assert_not user.save, "Saved the user without its first_name"
    end
 
    test "should not save user without its field last_name" do
      user = User.new
+     user.email='wonook@wonook.me'
      user.username='Alia'
-     user.login_approval='Not_Yet'
      user.first_name='Aliaa'
      assert_not user.save, "Saved the user without its last_name"
    end
 
    test "password and its confirmation are same" do
      user = User.new
+     user.email='wonook@wonook.me'
      user.username='Alia'
-     user.login_approval='Not_Yet'
      user.first_name='Aliaa'
      user.last_name='Bhatt'
      user.password='Alia'
@@ -94,8 +94,8 @@ class UserTest < ActiveSupport::TestCase
 
    test "password (is empty) and its confirmation are different" do
      user = User.new
+     user.email='wonook@wonook.me'
      user.username='Alia'
-     user.login_approval='Not_Yet'
      user.first_name='Aliaa'
      user.last_name='Bhatt'
      user.password=''
@@ -105,8 +105,8 @@ class UserTest < ActiveSupport::TestCase
 
    test "password and its confirmation are different" do
      user = User.new
+     user.email='wonook@wonook.me'
      user.username='Alia'
-     user.login_approval='Not_Yet'
      user.first_name='Aliaa'
      user.last_name='Bhatt'
      user.password='Not'


### PR DESCRIPTION
Issue #45 - Fix Login Approval under Users Index

1.Rewrote Users Index with ReactJS
2.Replaced the `login_approval`(string) column in users to `login_approval_at`(datetime).
  -It didn't really mean anything more than a bool before.
3.Implemented the Login Approval in a better manner using ReactJS (We can do it real-time now).

Miscellaneous fixes:
1.Fixed wrong indentations and missing closing html tags in a number of the views.
2.Added email as a required field upon signing up. (It didn't let users sign in with empty emails when there were other users with empty emails b/c of the `unique` restriction)

NOTICE: 
-Please refer to the syntax used in `app/assets/javascripts/components/users/index.js.jsx.coffee` for later implementations using CoffeeScript and ReactJS.
-Notice that `@blah` means `this.blah` in CoffeeScript.

Author : @wonook - Won Wook SONG (wsong0512@gmail.com)

This pull request closes #45 