### PR TITLE
Plt#30 organizations

### DIFF
--- a/app/admin/organizations.rb
+++ b/app/admin/organizations.rb
@@ -1,0 +1,11 @@
+ActiveAdmin.register Organization do
+  permit_params :name
+
+  form do |f|
+    f.inputs "New Organization" do
+      f.input :name
+    end
+    f.actions
+  end
+
+end

--- a/app/assets/javascripts/components/users/index.js.jsx.coffee
+++ b/app/assets/javascripts/components/users/index.js.jsx.coffee
@@ -38,8 +38,17 @@
   render: ->
     clickApproval = @handleApproval
     organizations = @props.data.organizations
+    admins = @props.data.admins
+    volunteers = @props.data.volunteers
+    contributors = @props.data.contributors
     userNodes = @props.data.users.map((user) ->
-      `<UserNode key={user.id} user={user} organization={organizations[user.organization_id - 1]} onUserApproval={clickApproval}/>`)
+      organization = organizations[user.organization_id - 1]
+      role =
+        if (admins.indexOf(user.id) > -1) then 'Admin'
+        else if (volunteers.indexOf(user.id) > -1) then 'Volunteer'
+        else if (contributors.indexOf(user.id) > -1) then 'Contributor'
+        else 'Guest'
+      `<UserNode key={user.id} user={user} organization={organization} role={role} onUserApproval={clickApproval}/>`)
     `<table className="UserIndexList table table-striped">
       <thead>
         <tr>
@@ -51,6 +60,7 @@
           <th>Location</th>
           <th>Language</th>
           <th>Mobile</th>
+          <th>Role</th>
           <th>Login Approval</th>
         </tr>
       </thead>
@@ -79,5 +89,6 @@
       <td>{this.props.user.location}</td>
       <td>{this.props.user.lang}</td>
       <td>{this.props.user.contact}</td>
+      <td>{this.props.role}</td>
       <td>{login_approval}</td>
     </tr>`

--- a/app/assets/javascripts/components/users/index.js.jsx.coffee
+++ b/app/assets/javascripts/components/users/index.js.jsx.coffee
@@ -37,11 +37,13 @@
     @props.onUserApproval(data)
   render: ->
     clickApproval = @handleApproval
-    userNodes = @props.data.map((user) ->
-      `<UserNode key={user.id} user={user} onUserApproval={clickApproval}/>`)
+    organizations = @props.data.organizations
+    userNodes = @props.data.users.map((user) ->
+      `<UserNode key={user.id} user={user} organization={organizations[user.organization_id - 1]} onUserApproval={clickApproval}/>`)
     `<table className="UserIndexList table table-striped">
       <thead>
         <tr>
+          <th>Organization</th>
           <th>Name</th>
           <th>Gender</th>
           <th>Email</th>
@@ -69,6 +71,7 @@
       else `<div>Waiting<button onClick={this.handleApproval} className='btn btn-default'><span className='glyphicon glyphicon-ok' /></button></div>`
     show_url = "members/" + @props.user.id
     `<tr>
+      <td>{this.props.organization.name}</td>
       <td><a href={show_url}>{this.props.user.first_name} {this.props.user.last_name}</a></td>
       <td>{this.props.user.gender}</td>
       <td>{this.props.user.email}</td>

--- a/app/assets/javascripts/organizations.coffee
+++ b/app/assets/javascripts/organizations.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/organizations.scss
+++ b/app/assets/stylesheets/organizations.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Organizations controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -1,0 +1,69 @@
+body {
+  background-color: #fff;
+  color: #333;
+  font-family: verdana, arial, helvetica, sans-serif;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+p, ol, ul, td {
+  font-family: verdana, arial, helvetica, sans-serif;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+pre {
+  background-color: #eee;
+  padding: 10px;
+  font-size: 11px;
+}
+
+a {
+  color: #000;
+  &:visited {
+    color: #666;
+  }
+  &:hover {
+    color: #fff;
+    background-color: #000;
+  }
+}
+
+div {
+  &.field, &.actions {
+    margin-bottom: 10px;
+  }
+}
+
+#notice {
+  color: green;
+}
+
+.field_with_errors {
+  padding: 2px;
+  background-color: red;
+  display: table;
+}
+
+#error_explanation {
+  width: 450px;
+  border: 2px solid red;
+  padding: 7px;
+  padding-bottom: 0;
+  margin-bottom: 20px;
+  background-color: #f0f0f0;
+  h2 {
+    text-align: left;
+    font-weight: bold;
+    padding: 5px 5px 5px 15px;
+    font-size: 12px;
+    margin: -7px;
+    margin-bottom: 0px;
+    background-color: #c00;
+    color: #fff;
+  }
+  ul li {
+    font-size: 12px;
+    list-style: square;
+  }
+}

--- a/app/controllers/installations_controller.rb
+++ b/app/controllers/installations_controller.rb
@@ -46,6 +46,6 @@ class InstallationsController < ApplicationController
 
  private
    def installation_params
-       params.require(:installation).permit(:installation, :email, :address, :contact)
+       params.require(:installation).permit(:installation, :email, :address, :contact, :organization_id)
    end
 end

--- a/app/controllers/installations_controller.rb
+++ b/app/controllers/installations_controller.rb
@@ -10,7 +10,7 @@ class InstallationsController < ApplicationController
  end
 
  def index
-   @installations = Installation.page(params[:page]).per(20)
+   @installations = current_user.organization.installations.page(params[:page]).per(20)
  end
 
  def show
@@ -36,6 +36,7 @@ class InstallationsController < ApplicationController
 
  def create
      @installation = Installation.new(installation_params)
+     @installation.organization_id = current_user.organization.id
 	 
      if @installation.save
         redirect_to @installation

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,4 +1,6 @@
 class OrganizationsController < ApplicationController
+  load_and_authorize_resource
+
   before_action :set_organization, only: [:show, :edit, :update, :destroy]
 
   # GET /organizations

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,0 +1,74 @@
+class OrganizationsController < ApplicationController
+  before_action :set_organization, only: [:show, :edit, :update, :destroy]
+
+  # GET /organizations
+  # GET /organizations.json
+  def index
+    @organizations = Organization.all
+  end
+
+  # GET /organizations/1
+  # GET /organizations/1.json
+  def show
+  end
+
+  # GET /organizations/new
+  def new
+    @organization = Organization.new
+  end
+
+  # GET /organizations/1/edit
+  def edit
+  end
+
+  # POST /organizations
+  # POST /organizations.json
+  def create
+    @organization = Organization.new(organization_params)
+
+    respond_to do |format|
+      if @organization.save
+        format.html { redirect_to @organization, notice: 'Organization was successfully created.' }
+        format.json { render :show, status: :created, location: @organization }
+      else
+        format.html { render :new }
+        format.json { render json: @organization.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /organizations/1
+  # PATCH/PUT /organizations/1.json
+  def update
+    respond_to do |format|
+      if @organization.update(organization_params)
+        format.html { redirect_to @organization, notice: 'Organization was successfully updated.' }
+        format.json { render :show, status: :ok, location: @organization }
+      else
+        format.html { render :edit }
+        format.json { render json: @organization.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /organizations/1
+  # DELETE /organizations/1.json
+  def destroy
+    @organization.destroy
+    respond_to do |format|
+      format.html { redirect_to organizations_url, notice: 'Organization was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_organization
+      @organization = Organization.find(params[:id])
+    end
+
+    # Never trust parameters from the scary internet, only allow the white list through.
+    def organization_params
+      params.require(:organization).permit(:name)
+    end
+end

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -6,7 +6,10 @@ class SitesController < ApplicationController
   end
 
   def index
-    @sites = Site.page(params[:page]).per(20)
+    current_user.organization.installations.each do |a|
+      @sites << a.sites
+    end
+    @sites = @sites.page(params[:page]).per(20)
   end
 
   def create

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -63,9 +63,9 @@ class SitesController < ApplicationController
         end
       end
     elsif(action == 'contributor')
-      repond_to do |format|
+      respond_to do |format|
         if @user.add_role :contributor, @site
-          format.json { render json: (User.with_role :volunteer, @site), status: :ok}
+          format.json { render json: (User.with_role :contributor, @site), status: :ok}
         else
           format.json { render json: @user.errors, status: :unprocessable_entity}
         end
@@ -87,9 +87,9 @@ class SitesController < ApplicationController
         end
       end
     elsif(action == 'contributor')
-      repond_to do |format|
+      respond_to do |format|
         if @user.remove_role :contributor, @site
-          format.json { render json: (User.with_role :volunteer, @site), status: :ok}
+          format.json { render json: (User.with_role :contributor, @site), status: :ok}
         else
           format.json { render json: @user.errors, status: :unprocessable_entity}
         end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -71,7 +71,7 @@ class UsersController < ApplicationController
  
   private
   def user_params
-    params.require(:user).permit(:first_name, :last_name, :email, :username, :location, :lang, :contact, :gender)
+    params.require(:user).permit(:first_name, :last_name, :email, :username, :location, :lang, :contact, :gender, :organization_id)
   end
 
   def set_user

--- a/app/helpers/organizations_helper.rb
+++ b/app/helpers/organizations_helper.rb
@@ -1,0 +1,2 @@
+module OrganizationsHelper
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -11,7 +11,9 @@ class Ability
       can :manage, :all
       can :read, ActiveAdmin::Page, name: "Dashboard", namespace_name: :superadmin
     elsif user.has_role? :admin
-      can :manage, :all
+      can :manage, [Language, Category, Article]
+      can :manage, [Installation, User], organization_id: @user.organization.id
+      can :manage, Site, installation_id: @user.organization.installations.map { |a| a.id }
     elsif user.has_role? :volunteer
       can [:read, :update], Site
       can :read, [Language]

--- a/app/models/installation.rb
+++ b/app/models/installation.rb
@@ -15,5 +15,5 @@
 class Installation < ActiveRecord::Base
  belongs_to :organization
  has_many :sites, dependent: :destroy
- validates :installation, presence: true
+ validates_presence_of :installation, :organization_id
 end

--- a/app/models/installation.rb
+++ b/app/models/installation.rb
@@ -2,16 +2,18 @@
 #
 # Table name: installations
 #
-#  id           :integer          not null, primary key
-#  installation :string
-#  email        :string
-#  address      :text
-#  contact      :string
-#  created_at   :datetime
-#  updated_at   :datetime
+#  id              :integer          not null, primary key
+#  installation    :string
+#  email           :string
+#  address         :text
+#  contact         :string
+#  created_at      :datetime
+#  updated_at      :datetime
+#  organization_id :integer
 #
 
 class Installation < ActiveRecord::Base
- has_many :sites , dependent: :destroy
+ belongs_to :organization
+ has_many :sites, dependent: :destroy
  validates :installation, presence: true
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,0 +1,2 @@
+class Organization < ActiveRecord::Base
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,2 +1,15 @@
+# == Schema Information
+#
+# Table name: organizations
+#
+#  id         :integer          not null, primary key
+#  name       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 class Organization < ActiveRecord::Base
+  has_many :users
+  has_many :installations
+  validates :name, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,11 +25,14 @@
 #  tsv_data               :tsvector
 #  authentication_token   :string
 #  login_approval_at      :datetime
+#  organization_id        :integer
 #
 
 class User < ActiveRecord::Base
   rolify
   include PgSearch
+
+  belongs_to :organization
   
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,7 +42,7 @@ class User < ActiveRecord::Base
   default_scope -> { order('created_at DESC') }
   validates_uniqueness_of :username
   validates_confirmation_of :password, length: { in: 6..20 }
-  validates_presence_of :username, :email, :first_name, :last_name
+  validates_presence_of :username, :email, :first_name, :last_name, :organization_id
 
   before_save :ensure_authentication_token
 

--- a/app/serializers/organization_serializer.rb
+++ b/app/serializers/organization_serializer.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: organizations
+#
+#  id         :integer          not null, primary key
+#  name       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 class OrganizationSerializer < ActiveModel::Serializer
   attributes :id, :name
 end

--- a/app/serializers/organization_serializer.rb
+++ b/app/serializers/organization_serializer.rb
@@ -1,0 +1,3 @@
+class OrganizationSerializer < ActiveModel::Serializer
+  attributes :id, :name
+end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -6,6 +6,12 @@
     <legend>Edit <%= resource_name.to_s.humanize %> Profile</legend>
     <%= devise_error_messages! %>
 
+    <div class="form-group">
+       <%= f.label :organization_id, "Organization", class: "control-label col-sm-3" %>
+       <div class="col-sm-3">
+          <%= f.collection_select(:organization_id, Organization.all, :id, :name, prompt: true) %>
+       </div>
+    </div>
 
     <div class="form-group">
       <%= f.label :email, class: "control-label col-sm-3" %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -8,6 +8,13 @@
       <%= devise_error_messages! %>
 
       <div class="form-group">
+        <%= f.label :organization_id, "Organization", class: "control-label col-sm-3" %>
+        <div class="col-sm-3">
+          <%= f.collection_select(:organization_id, Organization.all, :id, :name, prompt: true) %>
+        </div>
+      </div>
+
+      <div class="form-group">
         <%= f.label :email, class: "control-label col-sm-3" %>
         <div class="col-sm-3">
           <%= f.text_field :email, class: "form-control" %>

--- a/app/views/installations/_form.html.erb
+++ b/app/views/installations/_form.html.erb
@@ -16,6 +16,13 @@
     <% end %>
 
     <div class="form-group">
+      <%= f.label :organization_id, "Organization", class: "control-label col-sm-3" %>
+      <div class="col-sm-3">
+        <%= f.collection_select(:organization_id, Organization.all, :id, :name, prompt: true) %>
+      </div>
+    </div>
+
+    <div class="form-group">
       <%= f.label :installation, "Post", class: "control-label col-sm-3" %>
       <div class="col-sm-3">
         <%= f.text_field :installation, class: "form-control" %>

--- a/app/views/installations/_form.html.erb
+++ b/app/views/installations/_form.html.erb
@@ -15,7 +15,7 @@
       </div>
     <% end %>
 
-    <div class="form-group">
+    <div class="form-group hidden">
       <%= f.label :organization_id, "Organization", class: "control-label col-sm-3" %>
       <div class="col-sm-3">
         <%= f.collection_select(:organization_id, Organization.all, :id, :name, prompt: true) %>

--- a/app/views/installations/index.html.erb
+++ b/app/views/installations/index.html.erb
@@ -2,6 +2,7 @@
 
 <table class="table table-striped">
   <tr>
+     <th>Organization</th>
      <th>Post</th>
      <th>Email Id</th>
      <th>Address</th>
@@ -11,6 +12,7 @@
 
 <% @installations.each do |installation| %>
   <tr>
+     <td><%= installation.organization.name %></td>
      <td><%= installation.installation %></td>
      <td><%= installation.email %></td>
      <td><%= installation.address %></td>

--- a/app/views/installations/show.html.erb
+++ b/app/views/installations/show.html.erb
@@ -4,6 +4,11 @@
 <h1>Saved post contact information</h1>
 
 <p>
+  <strong>Organization:</strong>
+  <%= @installation.organization.name %>
+</p>
+
+<p>
   <strong>Post:</strong>
   <%= @installation.installation %>
 </p>

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -1,0 +1,21 @@
+<%= form_for(@organization) do |f| %>
+  <% if @organization.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(@organization.errors.count, "error") %> prohibited this organization from being saved:</h2>
+
+      <ul>
+      <% @organization.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= f.label :name %><br>
+    <%= f.text_field :name %>
+  </div>
+  <div class="actions">
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/organizations/edit.html.erb
+++ b/app/views/organizations/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Organization</h1>
+
+<%= render 'form' %>
+
+<%= link_to 'Show', @organization %> |
+<%= link_to 'Back', organizations_path %>

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -1,0 +1,27 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Listing Organizations</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @organizations.each do |organization| %>
+      <tr>
+        <td><%= organization.name %></td>
+        <td><%= link_to 'Show', organization %></td>
+        <td><%= link_to 'Edit', edit_organization_path(organization) %></td>
+        <td><%= link_to 'Destroy', organization, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Organization', new_organization_path %>

--- a/app/views/organizations/index.json.jbuilder
+++ b/app/views/organizations/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array!(@organizations) do |organization|
+  json.extract! organization, :id, :name
+  json.url organization_url(organization, format: :json)
+end

--- a/app/views/organizations/new.html.erb
+++ b/app/views/organizations/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Organization</h1>
+
+<%= render 'form' %>
+
+<%= link_to 'Back', organizations_path %>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -1,0 +1,9 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Name:</strong>
+  <%= @organization.name %>
+</p>
+
+<%= link_to 'Edit', edit_organization_path(@organization) %> |
+<%= link_to 'Back', organizations_path %>

--- a/app/views/organizations/show.json.jbuilder
+++ b/app/views/organizations/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.extract! @organization, :id, :name, :created_at, :updated_at

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -15,6 +15,13 @@
     <% end %>
 
     <div class="form-group">
+      <%= f.label :organization_id, "Organization", class: "control-label col-sm-3" %>
+      <div class="col-sm-3">
+        <%= f.collection_select(:organization_id, Organization.all, :id, :name, prompt: true) %>
+      </div>
+    </div>
+
+    <div class="form-group">
       <%= f.label :username, class: "control-label col-sm-3" %>
       <div class="col-sm-3">
         <%= f.text_field :username, class: "form-control" %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,3 +1,8 @@
 <%= render partial: "search_form" %>
 
-<%= react_component 'UsersIndexBox', {data: {users: @users, organizations: Organization.order(:id)}} %>
+<%= react_component 'UsersIndexBox', {data: {
+        users: @users,
+        organizations: Organization.order(:id) ,
+        admins: User.with_role(:admin).map{|a| a.id},
+        volunteers: User.with_role(:volunteer, :any).map{|a| a.id},
+        contributors: User.with_role(:contributor, :any).map{|a| a.id} }} %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,3 +1,3 @@
 <%= render partial: "search_form" %>
 
-<%= react_component 'UsersIndexBox', {data: @users} %>
+<%= react_component 'UsersIndexBox', {data: {users: @users, organizations: Organization.order(:id)}} %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,6 +1,9 @@
 <h2>Contact Information</h2>
 
 <dl class="dl-horizontal">
+  <dt>Organization</dt>
+  <dd><%= @user.organization.name %></dd>
+
   <dt>First Name</dt>
   <dd><%= @user.first_name %></dd>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,8 @@ Rails.application.routes.draw do
     post  "users/regenerate_api_key", to: "registrations#regenerate_api_key"
   end
 
+  resources :organizations
+
   resources :installations do
     resources :sites
   end

--- a/db/migrate/20150715161314_create_organizations.rb
+++ b/db/migrate/20150715161314_create_organizations.rb
@@ -1,0 +1,9 @@
+class CreateOrganizations < ActiveRecord::Migration
+  def change
+    create_table :organizations do |t|
+      t.string :name
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20150716131426_drop_table_contributor_volunteer.rb
+++ b/db/migrate/20150716131426_drop_table_contributor_volunteer.rb
@@ -1,0 +1,6 @@
+class DropTableContributorVolunteer < ActiveRecord::Migration
+  def change
+    drop_table :volunteers
+    drop_table :contributors
+  end
+end

--- a/db/migrate/20150716181235_attach_organization_ref_to_users_and_installations.rb
+++ b/db/migrate/20150716181235_attach_organization_ref_to_users_and_installations.rb
@@ -1,0 +1,6 @@
+class AttachOraganizationRefToUsersAndInstallations < ActiveRecord::Migration
+  def change
+    add_reference :users, :organization, index: true, foreign_key: true
+    add_reference :installations, :organization, index: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150715161314) do
+ActiveRecord::Schema.define(version: 20150716131426) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -52,15 +52,6 @@ ActiveRecord::Schema.define(version: 20150715161314) do
   end
 
   add_index "categories", ["name"], name: "index_categories_on_name", using: :btree
-
-  create_table "contributors", force: :cascade do |t|
-    t.string   "name"
-    t.integer  "site_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  add_index "contributors", ["site_id"], name: "index_contributors_on_site_id", using: :btree
 
   create_table "installations", force: :cascade do |t|
     t.string   "installation"
@@ -139,14 +130,5 @@ ActiveRecord::Schema.define(version: 20150715161314) do
   end
 
   add_index "users_roles", ["user_id", "role_id"], name: "index_users_roles_on_user_id_and_role_id", using: :btree
-
-  create_table "volunteers", force: :cascade do |t|
-    t.string   "vname"
-    t.integer  "site_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  add_index "volunteers", ["site_id"], name: "index_volunteers_on_site_id", using: :btree
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150713185005) do
+ActiveRecord::Schema.define(version: 20150715161314) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,6 +75,12 @@ ActiveRecord::Schema.define(version: 20150713185005) do
     t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
+  end
+
+  create_table "organizations", force: :cascade do |t|
+    t.string   "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "roles", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150716131426) do
+ActiveRecord::Schema.define(version: 20150716181235) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,7 +60,10 @@ ActiveRecord::Schema.define(version: 20150716131426) do
     t.string   "contact"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "organization_id"
   end
+
+  add_index "installations", ["organization_id"], name: "index_installations_on_organization_id", using: :btree
 
   create_table "languages", force: :cascade do |t|
     t.string   "name"
@@ -117,10 +120,12 @@ ActiveRecord::Schema.define(version: 20150716131426) do
     t.tsvector "tsv_data"
     t.string   "authentication_token"
     t.datetime "login_approval_at"
+    t.integer  "organization_id"
   end
 
   add_index "users", ["authentication_token"], name: "index_users_on_authentication_token", unique: true, using: :btree
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
+  add_index "users", ["organization_id"], name: "index_users_on_organization_id", using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   add_index "users", ["tsv_data"], name: "index_users_tsv", using: :gin
 
@@ -131,4 +136,6 @@ ActiveRecord::Schema.define(version: 20150716131426) do
 
   add_index "users_roles", ["user_id", "role_id"], name: "index_users_roles_on_user_id_and_role_id", using: :btree
 
+  add_foreign_key "installations", "organizations"
+  add_foreign_key "users", "organizations"
 end

--- a/test/controllers/installations_controller_test.rb
+++ b/test/controllers/installations_controller_test.rb
@@ -37,7 +37,7 @@ class InstallationsControllerTest < ActionController::TestCase
   end
 
   test "should delete installation along with all sites under that installation" do
-    installation = Installation.create!({installation: 'Azerbaijan'})
+    installation = Installation.create!({installation: 'Azerbaijan', organization_id: @user.organization.id })
     site = Site.create!({installation_id: installation.id, name:'Leh'})
 
     assert_difference('Installation.count',-1) do

--- a/test/controllers/sites_controller_test.rb
+++ b/test/controllers/sites_controller_test.rb
@@ -26,20 +26,24 @@ class SitesControllerTest < ActionController::TestCase
   end
 
   test "should create site and go to its show page" do
+    installation = Installation.create({installation: 'Azerbaijan', organization_id: @user.organization.id })
+
     assert_difference('Site.count') do
-        post :create, site: {name: 'Devoll'}
+        post :create, site: {name: 'Devoll', installation_id: installation.id}
     end
     assert_redirected_to site_path(assigns(:site))
   end
 
-  test "should not create language without its name" do
+  test "should not create site without its name" do
+    installation = Installation.create({installation: 'Azerbaijan', organization_id: @user.organization.id })
+
     assert_no_difference('Site.count') do
-      post :create, site: {name: nil}
+      post :create, site: {name: nil, installation_id: installation.id }
     end
   end
 
   test "should delete site along with all volunteers and contributors under it" do
-    installation = Installation.create({installation: 'Azerbaijan'})
+    installation = Installation.create({installation: 'Azerbaijan', organization_id: @user.organization.id })
     site = Site.create!({installation_id: installation.id, name: 'Leh'})
 
     #volunteer = Volunteer.create({site_id: site.id, vname: 'Saumya'})

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -1,24 +1,18 @@
-FactoryGirl.define do  factory :role do
-    
-  end
-
-
-  factory :user do 
-    sequence(:email)          { |n| "test_user_#{n}@gmail.com" }
-    sequence(:first_name)     { |n| "Sherlock #{n}" }
-    sequence(:last_name)      { |n| "Holmes #{n}" }
-    password                  "testing123"
-    authentication_token      { Devise.friendly_token }
-    sequence(:username)       { |n| "uname_#{n}" }
-    login_approval_at         { 2.weeks.ago }
-  end
+FactoryGirl.define do
 
   factory :article do
+    language
+    category
     sequence(:english)        { |n| "English Text #{n}" }
     sequence(:phonetic)       { |n| "Phonetic Text #{n}" }
   end
 
+  factory :category do
+    name                      "Pet"
+  end
+
   factory :installation do
+    organization
     installation              "Location"
     sequence(:email)          { |n| "location_user_#{n}@gmail.com" }
     address                   "Location address"
@@ -29,12 +23,24 @@ FactoryGirl.define do  factory :role do
     name                      "English"
   end
 
+  factory :organization do
+    sequence(:name) { |n| "test_org_#{n}" }
+  end
+
   factory :site do
+    installation
     name                      "Site Name"
   end
 
-  factory :category do
-    name                      "Pet"
+  factory :user do
+    organization
+    sequence(:email)          { |n| "test_user_#{n}@gmail.com" }
+    sequence(:first_name)     { |n| "Sherlock #{n}" }
+    sequence(:last_name)      { |n| "Holmes #{n}" }
+    password                  "testing123"
+    authentication_token      { Devise.friendly_token }
+    sequence(:username)       { |n| "uname_#{n}" }
+    login_approval_at         { 2.weeks.ago }
   end
 
 end

--- a/test/models/installation_test.rb
+++ b/test/models/installation_test.rb
@@ -2,13 +2,14 @@
 #
 # Table name: installations
 #
-#  id           :integer          not null, primary key
-#  installation :string
-#  email        :string
-#  address      :text
-#  contact      :string
-#  created_at   :datetime
-#  updated_at   :datetime
+#  id              :integer          not null, primary key
+#  installation    :string
+#  email           :string
+#  address         :text
+#  contact         :string
+#  created_at      :datetime
+#  updated_at      :datetime
+#  organization_id :integer
 #
 
 require 'test_helper'

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -31,78 +31,88 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
-   test "the truth" do
-     assert true
-   end
+  test "the truth" do
+    assert true
+  end
 
-   test "should not save user without its fields username, email, first_name, last_name" do
-     user = User.new
-     assert_not user.save, "Saved the user without its compulsory fields"
-   end
+  setup do
+    @organization = create(:organization)
+  end
 
-   test "should not save user without its field email" do
-     user = User.new
-     user.username='Alia'
-     user.first_name='Aliaa'
-     user.last_name='Bhatt'
-     assert_not user.save, "Saved the user without its email"
-   end
+  def teardown
+    User.delete_all
+    Organization.delete_all
+  end
 
-   test "should not save user without its field username" do
-     user = User.new
-     user.email='wonook@wonook.me'
-     user.first_name='Aliaa'
-     user.last_name='Bhatt'
-     assert_not user.save, "Saved the user without its username"
-   end
+  test "should not save user without its fields username, email, first_name, last_name" do
+    user = User.new
+    assert_not user.save, "Saved the user without its compulsory fields"
+  end
 
-   test "should not save user without its field first_name" do
-     user = User.new
-     user.email='wonook@wonook.me'
-     user.username='Alia'
-     user.last_name='Bhatt'
-     assert_not user.save, "Saved the user without its first_name"
-   end
+  test "should not save user without its field email" do
+    user = User.new
+    user.username='Alia'
+    user.first_name='Aliaa'
+    user.last_name='Bhatt'
+    assert_not user.save, "Saved the user without its email"
+  end
 
-   test "should not save user without its field last_name" do
-     user = User.new
-     user.email='wonook@wonook.me'
-     user.username='Alia'
-     user.first_name='Aliaa'
-     assert_not user.save, "Saved the user without its last_name"
-   end
+  test "should not save user without its field username" do
+    user = User.new
+    user.email='wonook@wonook.me'
+    user.first_name='Aliaa'
+    user.last_name='Bhatt'
+    assert_not user.save, "Saved the user without its username"
+  end
 
-   test "password and its confirmation are same" do
-     user = User.new
-     user.email='wonook@wonook.me'
-     user.username='Alia'
-     user.first_name='Aliaa'
-     user.last_name='Bhatt'
-     user.password='Alia'
-     user.password_confirmation='Alia'
-     assert user.save, "Saved user has no authentication error"
-   end
+  test "should not save user without its field first_name" do
+    user = User.new
+    user.email='wonook@wonook.me'
+    user.username='Alia'
+    user.last_name='Bhatt'
+    assert_not user.save, "Saved the user without its first_name"
+  end
 
-   test "password (is empty) and its confirmation are different" do
-     user = User.new
-     user.email='wonook@wonook.me'
-     user.username='Alia'
-     user.first_name='Aliaa'
-     user.last_name='Bhatt'
-     user.password=''
-     user.password_confirmation='Alia'
-     assert_not user.save, "Saved user has empty sting as password authentication error"
-   end
+  test "should not save user without its field last_name" do
+    user = User.new
+    user.email='wonook@wonook.me'
+    user.username='Alia'
+    user.first_name='Aliaa'
+    assert_not user.save, "Saved the user without its last_name"
+  end
 
-   test "password and its confirmation are different" do
-     user = User.new
-     user.email='wonook@wonook.me'
-     user.username='Alia'
-     user.first_name='Aliaa'
-     user.last_name='Bhatt'
-     user.password='Not'
-     user.password_confirmation='Alia'
-     assert_not user.save, "Saved user has authentication error"
-   end
+  test "password and its confirmation are same" do
+    user = User.new
+    user.organization_id=@organization.id
+    user.email='wonook@wonook.me'
+    user.username='Alia'
+    user.first_name='Aliaa'
+    user.last_name='Bhatt'
+    user.password='Alia'
+    user.password_confirmation='Alia'
+    assert user.save, "Saved user has no authentication error"
+  end
+
+  test "password (is empty) and its confirmation are different" do
+    user = User.new
+    user.email='wonook@wonook.me'
+    user.username='Alia'
+    user.first_name='Aliaa'
+    user.last_name='Bhatt'
+    user.password=''
+    user.password_confirmation='Alia'
+    assert_not user.save, "Saved user has empty sting as password authentication error"
+  end
+
+  test "password and its confirmation are different" do
+    user = User.new
+    user.email='wonook@wonook.me'
+    user.username='Alia'
+    user.first_name='Aliaa'
+    user.last_name='Bhatt'
+    user.password='Not'
+    user.password_confirmation='Alia'
+    assert_not user.save, "Saved user has authentication error"
+  end
 
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -25,6 +25,7 @@
 #  tsv_data               :tsvector
 #  authentication_token   :string
 #  login_approval_at      :datetime
+#  organization_id        :integer
 #
 
 require 'test_helper'


### PR DESCRIPTION
Issue #30  - Organizations

1.Generated + migrated `Organization` model
2.Associated `Organization` model with `User` and `Installation` models. Organization has many of these two models.
3.Users are allowed to view the `Users` of the `organization` that the user belongs to only.
4.Users are allowed to view the `Installations` of the `organization` that the user belongs to only.
5.Users are allowed to view the `Sites` of the `Installations` that the user has access to only.
6.At the `Members` tab, you can view the `organization` and the `role` for each of the users that you have access to.
7.With the role, `superadmin`, you have access to ActiveAdmin and all of the objects.
8.Organizations can be modified through ActiveAdmin and cannot be accessed by users other than the `superadmin`

WARNING: Each of the `User` and `Installation` models now REQUIRE an `organization_id` attached to them. Without it, a number of the views might not work, so please confirm this validation before running the application.

miscellaneous cleanup: I dropped the contributor + volunteer table. We have already taken out the model, view, controller for these objects elsewhere, but never got to drop the tables.

Author : @wonook - Won Wook SONG (wsong0512@gmail.com)

This pull request closes #30