### PR TITLE
Plt#63 grant admin roles

### DIFF
--- a/app/assets/javascripts/components/sites/show.js.jsx.coffee
+++ b/app/assets/javascripts/components/sites/show.js.jsx.coffee
@@ -1,9 +1,12 @@
 @SitesShowBox = React.createClass
   getInitialState: ->
-    data: @props.data
+    site: @props.site
+    post: @props.post
+    volunteers: @props.volunteers
+    contributors: @props.contributors
   handleVolunteerAddition: (userdata) ->
     userdata.act = "volunteer"
-    userdata.site_id = @state.data.site.id
+    userdata.site_id = @state.site.id
     add_role_url = '/sites/add_role.json'
     $.ajax({
       url: add_role_url
@@ -11,9 +14,7 @@
       type: 'POST'
       data: userdata
       success: ((data) ->
-        newdata = @state.data
-        newdata.volunteers = data.sites #'data' is in form {sites: Array[n]}
-        @setState({data: newdata})
+        @setState({volunteers: data.sites}) #'data' is in form {sites: Array[n]}
       ).bind(this)
       error: ((xhr, status, err) ->
         console.error(add_role_url, status, err.toString())
@@ -21,7 +22,7 @@
     })
   handleContributorAddition: (userdata) ->
     userdata.act = "contributor"
-    userdata.site_id = @state.data.site.id
+    userdata.site_id = @state.site.id
     add_role_url = '/sites/add_role.json'
     $.ajax({
       url: add_role_url
@@ -29,16 +30,14 @@
       type: 'POST'
       data: userdata
       success: ((data) ->
-        newdata = @state.data
-        newdata.contributors = data.sites #'data' is in form {sites: Array[n]}
-        @setState({data: newdata})
+        @setState({contributors: data.sites}) #'data' is in form {sites: Array[n]}
       ).bind(this)
       error: ((xhr, status, err) ->
         console.error(add_role_url, status, err.toString())
       ).bind(this)
     })
   handleRoleRemoval: (userdata) ->
-    userdata.site_id = @state.data.site.id
+    userdata.site_id = @state.site.id
     remove_role_url = '/sites/remove_role.json'
     $.ajax({
       url: remove_role_url
@@ -46,13 +45,10 @@
       type: 'POST'
       data: userdata
       success: ((data) ->
-        newdata = @state.data
         if(userdata.act == 'volunteer')
-          newdata.volunteers = data.sites #'data' is in form {sites: Array[n]}
-          @setState({data: newdata})
+          @setState({volunteers: data.sites}) #'data' is in form {sites: Array[n]}
         else if(userdata.act == 'contributor')
-          newdata.contributors = data.sites #'data' is in form {sites: Array[n]}
-          @setState({data: newdata})
+          @setState({contributors: data.sites}) #'data' is in form {sites: Array[n]}
       ).bind(this)
       error: ((xhr, status, err) ->
         console.error(remove_role_url, status, err.toString())
@@ -60,15 +56,16 @@
     })
   render: ->
     `<div className="SitesShowBox">
-      <h1>{this.state.data.site.name} <span className="h4">{this.state.data.post.installation}</span></h1>
+      <h1>{this.state.site.name} <span className="h4">{this.state.post.installation}</span></h1>
       <br/>
-      <VolunteersList data={this.state.data.volunteers} onRoleAddition={this.handleVolunteerAddition} onRoleRemoval={this.handleRoleRemoval}/>
-      <ContributorsList data={this.state.data.contributors} onRoleAddition={this.handleContributorAddition} onRoleRemoval={this.handleRoleRemoval}/>
+      <VolunteersList data={this.state.volunteers} onRoleAddition={this.handleVolunteerAddition} onRoleRemoval={this.handleRoleRemoval}/>
+      <ContributorsList data={this.state.contributors} onRoleAddition={this.handleContributorAddition} onRoleRemoval={this.handleRoleRemoval}/>
     </div>`
 
 @VolunteersList = React.createClass
   handleRoleAddition: ->
     @props.onRoleAddition({username: React.findDOMNode(@refs.username).value.trim(), action: "", site_id: -1})
+    React.findDOMNode(@refs.username).value = ''
   handleRoleRemoval: (data) ->
     data.act = 'volunteer'
     @props.onRoleRemoval(data)
@@ -95,6 +92,7 @@
 @ContributorsList = React.createClass
   handleRoleAddition: ->
     @props.onRoleAddition({username: React.findDOMNode(@refs.username).value.trim(), act: "", site_id: -1})
+    React.findDOMNode(@refs.username).value = ''
   handleRoleRemoval: (data) ->
     data.act = 'contributor'
     @props.onRoleRemoval(data)

--- a/app/assets/javascripts/components/users/index.js.jsx.coffee
+++ b/app/assets/javascripts/components/users/index.js.jsx.coffee
@@ -1,6 +1,10 @@
 @UsersIndexBox = React.createClass
   getInitialState: ->
-    data: @props.data
+    users: @props.users
+    organizations: @props.organizations
+    admins: @props.admins
+    volunteers: @props.volunteers
+    contributors: @props.contributors
   handleUserApproval: (userdata) ->
     approveurl = 'members/approve.json'
     disapproveurl = 'members/disapprove.json'
@@ -11,7 +15,7 @@
         type: 'POST'
         data: {user_id: userdata.user_id}
         success: ((data) ->
-          @setState({data: data.users})).bind(this)
+          @setState({users: data.users})).bind(this)
         error: ((xhr, status, err) ->
           console.error(approveurl, status, err.toString())).bind(this)
       })
@@ -22,26 +26,34 @@
         type: 'POST'
         data: {user_id: userdata.user_id}
         success: ((data) ->
-          @setState({data: data.users})).bind(this)
+          @setState({users: data.users})).bind(this)
         error: ((xhr, status, err) ->
           console.error(disapproveurl, status, err.toString())).bind(this)
       })
   render: ->
+    users = @state.users
+    organizations = @state.organizations
+    admins = @state.admins
+    volunteers = @state.volunteers
+    contributors = @state.contributors
+
     `<div className="UsersIndexBox">
       <h3>Members</h3>
-      <UsersIndexList data={this.state.data} onUserApproval={this.handleUserApproval}/>
+      <UsersIndexList users={users} organizations={organizations} admins={admins} volunteers={volunteers}
+        contributors={contributors} onUserApproval={this.handleUserApproval}/>
     </div>`
+
 
 @UsersIndexList = React.createClass
   handleApproval: (data) ->
     @props.onUserApproval(data)
   render: ->
     clickApproval = @handleApproval
-    organizations = @props.data.organizations
-    admins = @props.data.admins
-    volunteers = @props.data.volunteers
-    contributors = @props.data.contributors
-    userNodes = @props.data.users.map((user) ->
+    organizations = @props.organizations
+    admins = @props.admins
+    volunteers = @props.volunteers
+    contributors = @props.contributors
+    userNodes = @props.users.map((user) ->
       organization = organizations[user.organization_id - 1]
       role =
         if (admins.indexOf(user.id) > -1) then 'Admin'
@@ -49,6 +61,7 @@
         else if (contributors.indexOf(user.id) > -1) then 'Contributor'
         else 'Guest'
       `<UserNode key={user.id} user={user} organization={organization} role={role} onUserApproval={clickApproval}/>`)
+
     `<table className="UserIndexList table table-striped">
       <thead>
         <tr>
@@ -67,6 +80,7 @@
       <tbody>{userNodes}</tbody>
     </table>`
 
+
 @UserNode = React.createClass
   handleApproval: ->
     user = @props.user
@@ -80,6 +94,7 @@
       then  `<div>{this.props.user.login_approval_at.slice(0,10)}<button onClick={this.handleApproval} className='btn btn-default'><span className='glyphicon glyphicon-remove' /></button></div>`
       else `<div>Waiting<button onClick={this.handleApproval} className='btn btn-default'><span className='glyphicon glyphicon-ok' /></button></div>`
     show_url = "members/" + @props.user.id
+
     `<tr>
       <td>{this.props.organization.name}</td>
       <td><a href={show_url}>{this.props.user.first_name} {this.props.user.last_name}</a></td>

--- a/app/assets/javascripts/components/users/show.js.jsx.coffee
+++ b/app/assets/javascripts/components/users/show.js.jsx.coffee
@@ -1,17 +1,44 @@
 @UsersShowBox = React.createClass
   getInitialState: ->
-    data: @props.data
-
+    current_user_roles: @props.current_user_roles
+    user: @props.user
+    user_roles: @props.user_roles
+    organization: @props.organization
+  handleAdminToggle: (userdata) ->
+    grant_url = '/members/grant_admin.json'
+    revoke_url = '/members/revoke_admin.json'
+    if userdata.action == 'grant'
+      $.ajax({
+        url: grant_url
+        dataType: 'json'
+        type: 'POST'
+        data: {user_id: userdata.user_id}
+        success: ((data) ->
+          @setState({user_roles: data.users})).bind(this)
+        error: ((xhr, status, err) ->
+          console.error(grant_url, status, err.toString())).bind(this)
+      })
+    else if userdata.action== 'revoke'
+      $.ajax({
+        url: revoke_url
+        dataType: 'json'
+        type: 'POST'
+        data: {user_id: userdata.user_id}
+        success: ((data) ->
+          @setState({user_roles: data.users})).bind(this)
+        error: ((xhr, status, err) ->
+          console.error(revoke_url, status, err.toString())).bind(this)
+      })
   render: ->
-    user = @state.data.user
-
-    organization = @state.data.organization
-
+    current_user_roles = @state.current_user_roles
+    user = @state.user
+    user_roles = @state.user_roles
+    organization = @state.organization
     gender = ''
-
     login_approval_message =
       if user.login_approval_at then ''
       else 'The user first needs to be approved to use the account.'
+    clickToggle = @handleAdminToggle
 
     `<div className="UsersShowBox">
       <h2>Contact Information</h2>
@@ -36,4 +63,26 @@
         <dd>{user.contact}</dd>
       </dl>
       <p className="text-center"><strong>{login_approval_message}</strong></p>
+      <ToggleAdminButton current_user_roles={current_user_roles} user={user} user_roles={user_roles} onToggleAdmin={clickToggle} />
     </div>`
+
+
+@ToggleAdminButton = React.createClass
+  handleToggle: ->
+    if ('admin' in @props.user_roles)
+      @props.onToggleAdmin({user_id: @props.user.id, action: 'revoke'})
+    else
+      @props.onToggleAdmin({user_id: @props.user.id, action: 'grant'})
+  render: ->
+    current_user_roles = @props.current_user_roles
+    user_roles = @props.user_roles
+    button_message =
+      if ('admin' in user_roles) then 'Revoke Admin Rights'
+      else 'Make Admin'
+
+    if ('admin' in current_user_roles or 'superadmin' in current_user_roles)
+      `<p className='text-center'>
+        <button onClick={this.handleToggle} className="btn btn-default">{button_message}</button>
+      </p>`
+    else
+      ``

--- a/app/assets/javascripts/components/users/show.js.jsx.coffee
+++ b/app/assets/javascripts/components/users/show.js.jsx.coffee
@@ -1,0 +1,39 @@
+@UsersShowBox = React.createClass
+  getInitialState: ->
+    data: @props.data
+
+  render: ->
+    user = @state.data.user
+
+    organization = @state.data.organization
+
+    gender = ''
+
+    login_approval_message =
+      if user.login_approval_at then ''
+      else 'The user first needs to be approved to use the account.'
+
+    `<div className="UsersShowBox">
+      <h2>Contact Information</h2>
+      <br/>
+      <dl className="dl-horizontal">
+        <dt>Organization</dt>
+        <dd>{organization.name}</dd>
+
+        <dt>Name</dt>
+        <dd>{user.first_name} {user.last_name}</dd>
+
+        <dt>Email</dt>
+        <dd>{user.email}</dd>
+
+        <dt>Location</dt>
+        <dd>{user.location}</dd>
+
+        <dt>Language</dt>
+        <dd>{user.lang}</dd>
+
+        <dt>Contact Number</dt>
+        <dd>{user.contact}</dd>
+      </dl>
+      <p className="text-center"><strong>{login_approval_message}</strong></p>
+    </div>`

--- a/app/controllers/installations_controller.rb
+++ b/app/controllers/installations_controller.rb
@@ -10,7 +10,11 @@ class InstallationsController < ApplicationController
  end
 
  def index
-   @installations = current_user.organization.installations.page(params[:page]).per(20)
+   if current_user.has_role? :superadmin
+     @installations = Installation.all.page(params[:page]).per(20)
+   else
+     @installations = current_user.organization.installations.page(params[:page]).per(20)
+   end
  end
 
  def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -45,6 +45,7 @@ class UsersController < ApplicationController
     end
   end
 
+  #Called from Users Index: app/assets/javascripts/components/users/index.js.jsx.coffee
   def approve_user
     @user = User.find(params[:user_id])
     @user.login_approval_at = Time.now
@@ -65,6 +66,31 @@ class UsersController < ApplicationController
         format.json { render json: User.accessible_by(current_ability), status: :ok }
       else
         format.json { render json: @user.errors, status: :unprocessable_entity}
+      end
+    end
+  end
+
+  #Called from Users Show: app/assets/javascripts/components/users/show.js.jsx.coffee
+  def grant_admin
+    @user = User.find(params[:user_id])
+    @user.add_role :admin
+    respond_to do |format|
+      if @user.save
+        format.json { render json: @user.roles.map{|a| a.name}, status: :ok }
+      else
+        format.json { render json: @user.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def revoke_admin
+    @user = User.find(params[:user_id])
+    @user.remove_role :admin
+    respond_to do |format|
+      if @user.save
+        format.json { render json: @user.roles.map{|a| a.name}, status: :ok }
+      else
+        format.json { render json: @user.errors, status: :unprocessable_entity }
       end
     end
   end

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -1,12 +1,12 @@
 <% if current_user.login_approval_at %>
 <% if current_user.has_any_role? :admin, :volunteer %>
 
-<%= react_component 'SitesShowBox',
-      {data: {
+<%= react_component 'SitesShowBox', {data: {
         site: @site,
         post: @site.installation,
         volunteers: @volunteers,
-        contributors: @contributors}}%>
+        contributors: @contributors
+    }}%>
 
 <%= link_to 'Back', sites_path %>
 <%= link_to 'Edit', edit_site_path(@site) %>

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -1,12 +1,12 @@
 <% if current_user.login_approval_at %>
 <% if current_user.has_any_role? :admin, :volunteer %>
 
-<%= react_component 'SitesShowBox', {data: {
+<%= react_component 'SitesShowBox', {
         site: @site,
         post: @site.installation,
         volunteers: @volunteers,
         contributors: @contributors
-    }}%>
+    }%>
 
 <%= link_to 'Back', sites_path %>
 <%= link_to 'Edit', edit_site_path(@site) %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,9 +1,9 @@
 <%= render partial: "search_form" %>
 
-<%= react_component 'UsersIndexBox', {data: {
+<%= react_component 'UsersIndexBox', {
         users: @users,
         organizations: Organization.order(:id) ,
         admins: User.with_role(:admin).map{|a| a.id},
         volunteers: User.with_role(:volunteer, :any).map{|a| a.id},
         contributors: User.with_role(:contributor, :any).map{|a| a.id}
-    }} %>
+    } %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -5,4 +5,5 @@
         organizations: Organization.order(:id) ,
         admins: User.with_role(:admin).map{|a| a.id},
         volunteers: User.with_role(:volunteer, :any).map{|a| a.id},
-        contributors: User.with_role(:contributor, :any).map{|a| a.id} }} %>
+        contributors: User.with_role(:contributor, :any).map{|a| a.id}
+    }} %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,6 +1,8 @@
-<%= react_component 'UsersShowBox', {data: {
+<%= react_component 'UsersShowBox', {
+        current_user_roles: current_user.roles.map{|a| a.name},
         user: @user,
+        user_roles: @user.roles.map{|a| a.name},
         organization: @user.organization
-    }} %>
+    } %>
 
 <%= link_to 'Edit', edit_user_path(@user) %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,33 +1,6 @@
-<h2>Contact Information</h2>
-
-<dl class="dl-horizontal">
-  <dt>Organization</dt>
-  <dd><%= @user.organization.name %></dd>
-
-  <dt>First Name</dt>
-  <dd><%= @user.first_name %></dd>
-
-  <dt>Last Name</dt>
-  <dd><%= @user.last_name %></dd>
-
-  <dt>Email</dt>
-  <dd><%= @user.email %></dd>
-
-  <dt>Gender</dt>
-  <dd><%= @user.gender %></dd>
-
-  <dt>Location</dt>
-  <dd><%= @user.location %></dd>
-
-  <dt>Language Contribution</dt>
-  <dd><%= @user.lang %></dd>
-
-  <dt>Contact Number</dt>
-  <dd><%= @user.contact %></dd>
-
-  <% if !@user.login_approval_at %>
-    <dd><b>The user first needs to be approved to use the account.</b></dd>
-  <% end %>
-</dl>
+<%= react_component 'UsersShowBox', {data: {
+        user: @user,
+        organization: @user.organization
+    }} %>
 
 <%= link_to 'Edit', edit_user_path(@user) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
   resources :users, path: :members
   post "members/approve", to: "users#approve_user"
   post "members/disapprove", to: "users#disapprove_user"
+  post "members/grant_admin", to: "users#grant_admin"
+  post "members/revoke_admin", to: "users#revoke_admin"
 
   devise_scope :user do
     post  "users/regenerate_api_key", to: "registrations#regenerate_api_key"


### PR DESCRIPTION
Issue #63  - Grant admin roles

1.Migrated Users Show view into ReactJS to grant admin roles interactively.
2.Users with `admin` or `superadmin` roles can now grant and revoke `admin` roles to users.
3.Fixed other ReactJS code to keep syntax consistency

other: Fixed the InstallationsController to display all Posts when the user has `superadmin` role

Author : @wonook - Won Wook SONG (wsong0512@gmail.com)

This pull request closes #63 