### PR TITLE
Plt#78 ability bugs

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -2,6 +2,11 @@ class SitesController < ApplicationController
   load_and_authorize_resource
 
   def new
+    if current_user.has_role? :superadmin
+      @installations = Installation.all
+    else
+      @installations = current_user.organization.installations
+    end
     @site = Site.new
   end
 
@@ -18,6 +23,11 @@ class SitesController < ApplicationController
     if @site.save
       redirect_to @site
     else
+      if current_user.has_role? :superadmin
+        @installations = Installation.all
+      else
+        @installations = current_user.organization.installations
+      end
       render 'new'
     end
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -14,8 +14,11 @@ class Ability
 
     elsif user.has_role? :admin
       #Admins all belong to an organization. They can manage Languages, Categories and Articles freely,
-      # but they can only manage the Installations, Sites, and Users that belong to their own organization.
+      # but they can only manage the Installations, Sites, and Users that belong to their own organization
+      # as well as read and update the organization they belong to.
       can :manage, [Language, Category, Article]
+      can [:read, :update], Organization,
+          id: @user.organization.id
       can :manage, [Installation, User],
           organization_id: @user.organization.id
       can :new, Site

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -15,6 +15,7 @@ class Ability
       can :manage, [Language, Category, Article]
       can :manage, [Installation, User],
           organization_id: @user.organization.id
+      can :new, Site
       can :manage, Site,
           installation_id: @user.organization.installations.map { |a| a.id }
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -8,10 +8,13 @@ class Ability
     # following roles exist: superadmin, admin, volunteer, contributor, guest, non-users
 
     if user.has_role? :superadmin
+      #Superadmins can do anything. They can also access the ActiveAdmin interface via http://the_site_address/admin
       can :manage, :all
       can :read, ActiveAdmin::Page, name: "Dashboard", namespace_name: :superadmin
 
     elsif user.has_role? :admin
+      #Admins all belong to an organization. They can manage Languages, Categories and Articles freely,
+      # but they can only manage the Installations, Sites, and Users that belong to their own organization.
       can :manage, [Language, Category, Article]
       can :manage, [Installation, User],
           organization_id: @user.organization.id
@@ -20,6 +23,9 @@ class Ability
           installation_id: @user.organization.installations.map { |a| a.id }
 
     elsif user.has_role? :volunteer, :any
+      #Volunteers all belong to an Organization as well as a Site. They can only read Languages and Categories, but they can
+      # manage Articles. They can also read other users, but they are only allowed to manage the contributors that belong
+      # to the same organization. They do not have access to other Installations, but they can read and update Sites.
       can :read, [Language, Category]
       can :manage, [Article]
       can :read, User,
@@ -28,13 +34,17 @@ class Ability
           organization_id: @user.organization.id,
           id: User.with_any_role({name: :contributor, resource: :any}, :guest).map { |a| a.id }
       can [:read, :update], Site,
-          installation_id: @user.organization.installations.map{ |a| a.id }
+          installation_id: @user.organization.installations.map { |a| a.id }
 
     elsif user.has_role? :contributor, :any
+      #Contributors all belong to an Organization as well as a Site. They can only read, create, and update Articles
       can [:read, :create, :update], Article
 
     else
+      #Guest users are only allowed to read Articles
       can :read, Article
+
+      #Non-users do not have access to any of the pages but the sign up page.
     end
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -25,7 +25,7 @@ class Ability
     elsif user.has_role? :volunteer, :any
       #Volunteers all belong to an Organization as well as a Site. They can only read Languages and Categories, but they can
       # manage Articles. They can also read other users, but they are only allowed to manage the contributors that belong
-      # to the same organization. They do not have access to other Installations, but they can read and update Sites.
+      # to the same organization. They do not have access to other Installations, but they can read and update the Site they belong to.
       can :read, [Language, Category]
       can :manage, [Article]
       can :read, User,
@@ -34,7 +34,7 @@ class Ability
           organization_id: @user.organization.id,
           id: User.with_any_role({name: :contributor, resource: :any}, :guest).map { |a| a.id }
       can [:read, :update], Site,
-          installation_id: @user.organization.installations.map { |a| a.id }
+          id: Site.with_role(:volunteer, @user).map { |a| a.id }
 
     elsif user.has_role? :contributor, :any
       #Contributors all belong to an Organization as well as a Site. They can only read, create, and update Articles

--- a/app/views/sites/_form.html.erb
+++ b/app/views/sites/_form.html.erb
@@ -7,7 +7,7 @@
     <div class="form-group">
       <%= f.label :installation_id, "Post", class: "control-label col-sm-3" %>
       <div class="col-sm-3">
-        <%= f.collection_select(:installation_id, Installation.all, :id, :installation)  %>
+        <%= f.collection_select(:installation_id, @installations, :id, :installation)  %>
       </div>
     </div>
 

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -8,6 +8,17 @@ SimpleNavigation::Configuration.run do |navigation|
       primary.item :users, 'Members', users_path, highlights_on: :subpath
     end
 
+    if current_user and current_user.has_role? :superadmin
+      primary.item :organizations, "Organizations", organizations_path, highlights_on: :subpath do |sub|
+        sub.dom_class = 'nav nav-pills'
+        sub.item :new_organization, 'New Organization', new_organization_path
+      end
+    end
+
+    if current_user and current_user.has_role? :admin
+      primary.item :organization, "My Organization", organization_path(current_user.organization)
+    end
+
     if current_user and current_user.has_any_role? :superadmin, :admin
       primary.item :posts, "Posts", installations_path, highlights_on: :subpath do |sub|
         sub.dom_class = 'nav nav-pills'

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -11,35 +11,39 @@ SimpleNavigation::Configuration.run do |navigation|
     if current_user and current_user.has_any_role? :superadmin, :admin
       primary.item :posts, "Posts", installations_path, highlights_on: :subpath do |sub|
         sub.dom_class = 'nav nav-pills'
-        sub.item :photos, 'New post', new_installation_path
+        sub.item :new_post, 'New post', new_installation_path
       end
     end
 
-    if current_user and current_user.has_any_role? :superadmin, :admin, {name: :volunteer, resource: :any}
+    if current_user and current_user.has_any_role? :superadmin, :admin
       primary.item :sites, "Sites", sites_path, highlights_on: :subpath do |sub|
         sub.dom_class = 'nav nav-pills'
-        sub.item :photos, 'New site', new_site_path
+        sub.item :new_site, 'New site', new_site_path
       end
+    end
+
+    if current_user and current_user.has_role? :volunteer, :any
+      primary.item :sites, "My Site", site_path(Site.with_role(:volunteer, current_user).first)
     end
 
     if current_user and current_user.has_any_role? :superadmin, :admin, {name: :volunteer, resource: :any}
       primary.item :languages, "Languages", languages_path, highlights_on: :subpath do |sub|
         sub.dom_class = 'nav nav-pills'
-        sub.item :photos, 'New language', new_language_path
+        sub.item :new_language, 'New language', new_language_path
       end
     end
 
     if current_user and current_user.has_any_role? :superadmin, :admin, {name: :volunteer, resource: :any}
       primary.item :category, "Category", categories_path, highlights_on: :subpath do |sub|
         sub.dom_class = 'nav nav-pills'
-        sub.item :category, 'New Category', new_category_path
+        sub.item :new_category, 'New Category', new_category_path
       end
     end
 
     if current_user and current_user.has_any_role? :superadmin, :admin, {name: :volunteer, resource: :any}, {name: :contributor, resource: :any}
       primary.item :photos, "Photos", articles_path, highlights_on: :subpath do |sub|
         sub.dom_class = 'nav nav-pills'
-        sub.item :photos, 'New photo', new_article_path
+        sub.item :new_photo, 'New photo', new_article_path
       end
     end
 


### PR DESCRIPTION
Issue #78  - Bugs related to Ability.rb

1.Admin ability have been fixed to enable admins to create Sites that belong to their organization.
2.Added comments for the `ability.rb` file to clear out users' abilities.
3.Volunteers belong to a single site, but they have been given access to multiple sites. I've limited their access to the site they belong to only.
4.Superadmins now have access to any of the organizations.
5.Admins are able to view and edit the organization they belong to.

Author : @wonook - Won Wook SONG (wsong0512@gmail.com)

This pull request closes #78 