### PR TITLE
93-Removing  and use Ruby on Enums, Queries for article state

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,8 +61,6 @@ gem 'active_model_serializers'
 gem 'kaminari'
 
 gem 'simple-navigation'
-# AASM - State machines for Ruby classes
-gem 'aasm'
 # A lightweight Sass tool set
 gem 'bourbon'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    aasm (4.2.0)
     actionmailer (4.2.1)
       actionpack (= 4.2.1)
       actionview (= 4.2.1)
@@ -281,7 +280,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aasm
   active_model_serializers
   activeadmin (~> 1.0.0.pre1)
   annotate

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -56,7 +56,7 @@ class ArticlesController < ApplicationController
 
   def publish
     respond_with(@article) do |format|
-      if @article.publish!
+      if @article.published!
         flash[:notice] = "The article has been published."
 
         format.html { redirect_to article_path(@article) }
@@ -72,7 +72,7 @@ class ArticlesController < ApplicationController
 
   def unpublish
     respond_with(@article) do |format|
-      if @article.unpublish!
+      if @article.draft!
         flash[:notice] = "The article has been drafted."
 
         format.html { redirect_to article_path(@article) }

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -16,7 +16,6 @@
 
 class Article < ActiveRecord::Base
   include PgSearch
-  include AASM
 
   belongs_to :language
   belongs_to :category
@@ -26,6 +25,7 @@ class Article < ActiveRecord::Base
 
   # default order when calling the Article model
   default_scope -> { order('created_at DESC') }
+  default_value_for :state, 0
 
   # CarrierWave integration for uploading pictures
   mount_uploader :picture, PictureUploader
@@ -44,17 +44,5 @@ class Article < ActiveRecord::Base
                       }
                   }
 
-  # AASM
-  aasm column: :state do
-    state :draft, initial: true
-    state :published
-
-    event :publish do
-      transitions from: :draft, to: :published
-    end
-
-    event :unpublish do
-      transitions from: :published, to: :draft
-    end
-  end
+  enum state:   [:draft, :published]
 end

--- a/db/migrate/20151208031448_change_state_to_status_for_articles.rb
+++ b/db/migrate/20151208031448_change_state_to_status_for_articles.rb
@@ -1,0 +1,7 @@
+class ChangeStateToStatusForArticles < ActiveRecord::Migration
+  def change
+    remove_column :articles, :state, :string
+
+    add_column :articles, :state, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150818001514) do
+ActiveRecord::Schema.define(version: 20151208031448) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,7 +40,7 @@ ActiveRecord::Schema.define(version: 20150818001514) do
     t.integer  "language_id"
     t.tsvector "tsv_data"
     t.integer  "category_id"
-    t.string   "state",       default: "draft"
+    t.integer  "state",       default: 0
   end
 
   add_index "articles", ["language_id"], name: "index_articles_on_language_id", using: :btree
@@ -128,6 +128,9 @@ ActiveRecord::Schema.define(version: 20150818001514) do
     t.string   "gender"
     t.string   "lang"
     t.tsvector "tsv_data"
+    t.string   "authentication_token"
+    t.datetime "login_approval_at"
+    t.integer  "organization_id"
     t.string   "invitation_token"
     t.datetime "invitation_created_at"
     t.datetime "invitation_sent_at"
@@ -136,9 +139,6 @@ ActiveRecord::Schema.define(version: 20150818001514) do
     t.integer  "invited_by_id"
     t.string   "invited_by_type"
     t.integer  "invitations_count",      default: 0
-    t.string   "authentication_token"
-    t.datetime "login_approval_at"
-    t.integer  "organization_id"
   end
 
   add_index "users", ["authentication_token"], name: "index_users_on_authentication_token", unique: true, using: :btree

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -52,12 +52,12 @@ class ArticlesControllerTest < ActionController::TestCase
     category = create(:category)
 
     article = Article.create!({
-                                  language_id: @language.id,
-                                  category_id: category.id,
-                                  english: "Foods",
-                                  phonetic: "Keema",
-                                  picture: Rack::Test::UploadedFile.new(File.join(Rails.root, 'test', 'support', 'picture', 'logo.jpg'))
-                              })
+        language_id: @language.id,
+        category_id: category.id,
+        english: "Foods",
+        phonetic: "Keema",
+        picture: Rack::Test::UploadedFile.new(File.join(Rails.root, 'test', 'support', 'picture', 'logo.jpg'))
+    })
 
     assert_difference('Article.count',-1) do
       delete :destroy, language_id: @language.id, id: article.id
@@ -66,6 +66,40 @@ class ArticlesControllerTest < ActionController::TestCase
 
     assert_nil Article.find_by_id(article.id)
     assert_not_nil Language.find_by_id(@language.id)
+  end
+
+  test "article change state to publish" do
+    @category = create(:category)
+    @article = Article.create!({
+      language_id: @language.id,
+      category_id: @category.id,
+      english: "Foods",
+      phonetic: "Keema",
+      picture: Rack::Test::UploadedFile.new(File.join(Rails.root, 'test', 'support', 'picture', 'logo.jpg'))
+    })
+
+    assert_equal "draft", @article.state
+
+    post :publish, id: @article
+    assert_equal "published", assigns(:article).state
+  end
+
+  test "article change state to unpublish" do
+    @category = create(:category)
+    @article = Article.create!({
+      language_id: @language.id,
+      category_id: @category.id,
+      english: "Foods",
+      phonetic: "Keema",
+      picture: Rack::Test::UploadedFile.new(File.join(Rails.root, 'test', 'support', 'picture', 'logo.jpg'))
+    })
+
+    @article.published!
+
+    assert_equal "published", @article.state
+
+    post :unpublish, id: @article
+    assert_equal "draft", assigns(:article).state
   end
 
 end


### PR DESCRIPTION
Hi All, 
I removed the `aasm` gem and replaced using Rails4 core functionality `enum`. This is related to #93 