### PR TITLE
Adds corresponding articles link to the dropdown of each language

### DIFF
--- a/GSoC2017-PLT-DevelopmentUpdate.md
+++ b/GSoC2017-PLT-DevelopmentUpdate.md
@@ -28,7 +28,7 @@
 
 13. [ ] Language name in any article user can choose it from a drop down box which has only those language names which were added under the "Languages" tab ( languages added by administrator.) or none option if the language name is not in the shown list of languages. This will help peace corps to train their volunteers at any post(installation) or site in any language without any restriction. (None as an option not available.)
 
-14. [ ] All photos(articles) of a paticular language can be seen under the "Languages" tab. User has to click on "Photos" link beside the language name for selecting a paticular language. Volunteers can click on this link for their training in a paticular language. (Not implemented.)
+14. [x] All photos(articles) of a paticular language can be seen under the "Languages" tab. User has to click on "Photos" link beside the language name for selecting a paticular language. Volunteers can click on this link for their training in a paticular language. (Not implemented.)
 
 15. [x] CAREFUL! : If a particular language is deleted, all the photos(articles) under that language are automatically deleted.
 

--- a/app/views/languages/index.html.erb
+++ b/app/views/languages/index.html.erb
@@ -54,6 +54,9 @@
                                         <a data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" class="button--icon" href="#"><i class="icon-action"></i></a>
                                         <ul class="dropdown-menu u-rightPopup">
                                             <li>
+                                                <%= link_to "Photos", language_articles_path(language) %>
+                                            </li>
+                                            <li>
                                                 <%= link_to 'Edit', edit_language_path(language) %>
                                             </li>
                                             <% if can? :destroy, language %>


### PR DESCRIPTION
* Used the existing route to add a link to the articles of a given language
* Unable to verify the implementation, as filterrific gem has been broken due to ember js
* But, the resulting route url suggests that the ode is working fine

NOTE:
* Needs to be verified after filteriffic gem is fixed (ember js broke ajax calls) then merged.

<!--
Thanks for your contribution!
-->

### Checklist

- [x] I read the [contributing guide](/CONTRIBUTING.md) and I've followed it.
- [x] Commit message gives complete and useful information about the changes under it.
- [x] I ran the code locally and checked for common errors and uncaught exceptions.
- [x] My code is unit testable.

After you submit your pull request, DO NOT close it or click 'Update Branch'.

Occasionally, you may be asked to rebase your branch.
